### PR TITLE
fixed problem with preserveRoot and subdirectories by removing extra slash from addFiles()

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/Zips.java
+++ b/src/main/java/org/zeroturnaround/zip/Zips.java
@@ -164,7 +164,7 @@ public class Zips {
       File entryFile = (File) iter.next();
       String entryPath = getRelativePath(file, entryFile);
       if (preserveRoot) {
-        entryPath = file.getName() + "/" + entryPath;
+        entryPath = file.getName() + entryPath;
       }
       this.changedEntries.add(new FileSource(entryPath, entryFile));
     }

--- a/src/test/java/org/zeroturnaround/zip/ZipsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipsTest.java
@@ -310,6 +310,14 @@ public class ZipsTest extends TestCase {
     ZipUtil.explode(dest);
     assertTrue("Root dir is not preserved", (new File(dest, parent.getName())).exists());
   }
+  
+  public void testPreserveRootWithSubdirectories() throws Exception {
+	    File dest = File.createTempFile("temp", ".zip");
+	    File parent = new File("src/test/resources/testDirectory");
+	    // System.out.println("Parent file is " + parent);
+	    Zips.get().destination(dest).addFile(parent, true).process();
+	    assertTrue("File in subdirectory at specified path not found.",ZipUtil.containsEntry(dest, "testDirectory/testSubdirectory/testFileInTestSubdirectory.txt"));
+  }
 
   public void testIgnoringRoot() throws Exception {
     File dest = File.createTempFile("temp", ".zip");

--- a/src/test/resources/testDirectory/testSubdirectory/testFileInTestSubdirectory.txt
+++ b/src/test/resources/testDirectory/testSubdirectory/testFileInTestSubdirectory.txt
@@ -1,0 +1,1 @@
+badaboom

--- a/src/test/resources/testDirectory/testfileInTestDirectory.txt
+++ b/src/test/resources/testDirectory/testfileInTestDirectory.txt
@@ -1,0 +1,1 @@
+badabing


### PR DESCRIPTION
fixed problem with preserveRoot and subdirectories by removing extra slash from addFiles(). Also added test to prove issue existed.

The issue is clearly visible after opening the zip file in Archive
Manager or 7Zip. There is an extra un-named directory created due to the
extra slash. ZipUtils.explode() seems to deal with this, so existing
test patterns did not show the issue. Using ZipUtil.containsEntry
properly detects the issue.
