### PR TITLE
Configurable compressionLevel in packEntries(), and correct a compressionMethod naming error

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ByteSource.java
+++ b/src/main/java/org/zeroturnaround/zip/ByteSource.java
@@ -26,7 +26,7 @@ public class ByteSource implements ZipEntrySource {
   private final String path;
   private final byte[] bytes;
   private final long time;
-  private final int compressionLevel;
+  private final int compressionMethod;
   private final long crc;
 
   public ByteSource(String path, byte[] bytes) {
@@ -36,16 +36,16 @@ public class ByteSource implements ZipEntrySource {
   public ByteSource(String path, byte[] bytes, long time) {
     this(path, bytes, time, -1);
   }
-  public ByteSource(String path, byte[] bytes, int compressionLevel) {
-    this(path, bytes, System.currentTimeMillis(), compressionLevel);
+  public ByteSource(String path, byte[] bytes, int compressionMethod) {
+    this(path, bytes, System.currentTimeMillis(), compressionMethod);
   }
 
-  public ByteSource(String path, byte[] bytes, long time, int compressionLevel) {
+  public ByteSource(String path, byte[] bytes, long time, int compressionMethod) {
     this.path = path;
     this.bytes = (byte[])bytes.clone();
     this.time = time;
-    this.compressionLevel = compressionLevel;
-    if(compressionLevel != -1) {
+    this.compressionMethod = compressionMethod;
+    if(compressionMethod != -1) {
       CRC32 crc32 = new CRC32();
       crc32.update(bytes);
       this.crc = crc32.getValue();
@@ -63,8 +63,8 @@ public class ByteSource implements ZipEntrySource {
     if (bytes != null) {
       entry.setSize(bytes.length);
     }
-    if(compressionLevel != -1) {
-      entry.setMethod(compressionLevel);
+    if(compressionMethod != -1) {
+      entry.setMethod(compressionMethod);
     }
     if(crc != -1L) {
       entry.setCrc(crc);

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -98,7 +98,23 @@ public final class ZipUtil {
   }
 
   /**
-   * Returns the compression level of a given entry of the ZIP file.
+   * Returns the compression method of a given entry of the ZIP file.
+   *
+   * @param zip
+   *          ZIP file.
+   * @param name
+   *          entry name.
+   * @return Returns <code>ZipEntry.STORED</code>, <code>ZipEntry.DEFLATED</code> or -1 if
+   * the ZIP file does not contain the given entry.
+   * @deprecated The compression level cannot be retrieved. This method exists only to ensure backwards compatibility with ZipUtil version 1.9, which returned the compression method, not the level.
+   */
+  @Deprecated
+  public static int getCompressionLevelOfEntry(File zip, String name) {
+    return getCompressionMethodOfEntry(zip, name);
+  }
+
+  /**
+   * Returns the compression method of a given entry of the ZIP file.
    *
    * @param zip
    *          ZIP file.
@@ -107,7 +123,7 @@ public final class ZipUtil {
    * @return Returns <code>ZipEntry.STORED</code>, <code>ZipEntry.DEFLATED</code> or -1 if
    * the ZIP file does not contain the given entry.
    */
-  public static int getCompressionLevelOfEntry(File zip, String name) {
+  public static int getCompressionMethodOfEntry(File zip, String name) {
     ZipFile zf = null;
     try {
       zf = new ZipFile(zip);
@@ -1816,11 +1832,11 @@ public final class ZipUtil {
    *          new entry bytes (or <code>null</code> if directory).
    * @param destZip
    *          new ZIP file created.
-   * @param compressionLevel
-   *          the new compression level (<code>ZipEntry.STORED</code> or <code>ZipEntry.DEFLATED</code>).
+   * @param compressionMethod
+   *          the new compression method (<code>ZipEntry.STORED</code> or <code>ZipEntry.DEFLATED</code>).
    */
-  public static void addEntry(File zip, String path, byte[] bytes, File destZip, final int compressionLevel) {
-    addEntry(zip, new ByteSource(path, bytes, compressionLevel), destZip);
+  public static void addEntry(File zip, String path, byte[] bytes, File destZip, final int compressionMethod) {
+    addEntry(zip, new ByteSource(path, bytes, compressionMethod), destZip);
   }
 
   /**
@@ -1851,13 +1867,13 @@ public final class ZipUtil {
    *          new ZIP entry path.
    * @param bytes
    *          new entry bytes (or <code>null</code> if directory).
-   * @param compressionLevel
-   *          the new compression level (<code>ZipEntry.STORED</code> or <code>ZipEntry.DEFLATED</code>).
+   * @param compressionMethod
+   *          the new compression method (<code>ZipEntry.STORED</code> or <code>ZipEntry.DEFLATED</code>).
    */
-  public static void addEntry(final File zip, final String path, final byte[] bytes, final int compressionLevel) {
+  public static void addEntry(final File zip, final String path, final byte[] bytes, final int compressionMethod) {
     operateInPlace(zip, new InPlaceAction() {
       public boolean act(File tmpFile) {
-        addEntry(zip, path, bytes, tmpFile, compressionLevel);
+        addEntry(zip, path, bytes, tmpFile, compressionMethod);
         return true;
       }
     });
@@ -2285,15 +2301,15 @@ public final class ZipUtil {
    *          new ZIP entry path.
    * @param bytes
    *          new entry bytes (or <code>null</code> if directory).
-   * @param compressionLevel
-   *          the new compression level (<code>ZipEntry.STORED</code> or <code>ZipEntry.DEFLATED</code>).
+   * @param compressionMethod
+   *          the new compression method (<code>ZipEntry.STORED</code> or <code>ZipEntry.DEFLATED</code>).
    * @return <code>true</code> if the entry was replaced.
    */
   public static boolean replaceEntry(final File zip, final String path, final byte[] bytes,
-                                     final int compressionLevel) {
+                                     final int compressionMethod) {
     return operateInPlace(zip, new InPlaceAction() {
       public boolean act(File tmpFile) {
-        return replaceEntry(zip, new ByteSource(path, bytes, compressionLevel), tmpFile);
+        return replaceEntry(zip, new ByteSource(path, bytes, compressionMethod), tmpFile);
       }
     });
   }

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1272,6 +1272,40 @@ public final class ZipUtil {
    *          call-back for renaming the entries.
    */
   public static void packEntries(File[] filesToPack, File destZipFile, NameMapper mapper) {
+    packEntries(filesToPack, destZipFile, mapper, DEFAULT_COMPRESSION_LEVEL);
+  }
+
+  /**
+   * Compresses the given files into a ZIP file.
+   * <p>
+   * The ZIP file must not be a directory and its parent directory must exist.
+   *
+   * @param filesToPack
+   *          files that needs to be zipped.
+   * @param destZipFile
+   *          ZIP file that will be created or overwritten.
+   * @param compressionLevel
+   *          compression level
+   */
+  public static void packEntries(File[] filesToPack, File destZipFile, int compressionLevel) {
+    packEntries(filesToPack, destZipFile, IdentityNameMapper.INSTANCE, compressionLevel);
+  }
+
+  /**
+   * Compresses the given files into a ZIP file.
+   * <p>
+   * The ZIP file must not be a directory and its parent directory must exist.
+   *
+   * @param filesToPack
+   *          files that needs to be zipped.
+   * @param destZipFile
+   *          ZIP file that will be created or overwritten.
+   * @param mapper
+   *          call-back for renaming the entries.
+   * @param compressionLevel
+   *          compression level
+   */
+  public static void packEntries(File[] filesToPack, File destZipFile, NameMapper mapper, int compressionLevel) {
     log.debug("Compressing '{}' into '{}'.", filesToPack, destZipFile);
 
     ZipOutputStream out = null;
@@ -1279,6 +1313,7 @@ public final class ZipUtil {
     try {
       fos = new FileOutputStream(destZipFile);
       out = new ZipOutputStream(new BufferedOutputStream(fos));
+      out.setLevel(compressionLevel);
 
       for (int i = 0; i < filesToPack.length; i++) {
         File fileToPack = filesToPack[i];

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1301,7 +1301,7 @@ public final class ZipUtil {
    * @param destZipFile
    *          ZIP file that will be created or overwritten.
    * @param compressionLevel
-   *          compression level
+   *          ZIP file compression level (speed versus filesize), e.g. <code>Deflater.NO_COMPRESSION</code>, <code>Deflater.BEST_SPEED</code>, or <code>Deflater.BEST_COMPRESSION</code>
    */
   public static void packEntries(File[] filesToPack, File destZipFile, int compressionLevel) {
     packEntries(filesToPack, destZipFile, IdentityNameMapper.INSTANCE, compressionLevel);
@@ -1319,7 +1319,7 @@ public final class ZipUtil {
    * @param mapper
    *          call-back for renaming the entries.
    * @param compressionLevel
-   *          compression level
+   *          ZIP file compression level (speed versus filesize), e.g. <code>Deflater.NO_COMPRESSION</code>, <code>Deflater.BEST_SPEED</code>, or <code>Deflater.BEST_COMPRESSION</code>
    */
   public static void packEntries(File[] filesToPack, File destZipFile, NameMapper mapper, int compressionLevel) {
     log.debug("Compressing '{}' into '{}'.", filesToPack, destZipFile);

--- a/src/test/java/org/zeroturnaround/zip/MainExamplesTest.java
+++ b/src/test/java/org/zeroturnaround/zip/MainExamplesTest.java
@@ -65,13 +65,19 @@ public final class MainExamplesTest extends TestCase {
     File outDir = File.createTempFile("prefix", "suffix");
     outDir.delete();
     outDir.mkdir();
-    
+
     File outFile = new File(outDir, "demo");
-    
+    FileOutputStream fio = new FileOutputStream(outFile);
+
     // so the zip file will be outDir/demo <- this is a zip archive
-    FileUtils.copy(demoFile, new FileOutputStream(outFile));
+    FileUtils.copy(demoFile, fio);
+
+    // close the stream so that locks on the file can be released (on windows, not doing this prevents the file from being moved)
+    fio.close();
+
     // we explode the zip archive
     ZipUtil.explode(outFile);
+
     // we expect the outDir/demo/foo.txt to exist now
     assertTrue((new File(outFile, FOO_TXT)).exists());
   }

--- a/src/test/java/org/zeroturnaround/zip/ZTFileUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZTFileUtilTest.java
@@ -45,7 +45,7 @@ public class ZTFileUtilTest extends TestCase {
     Collection<File> files = ZTFileUtil.listFiles(new File("."), new FileFilter() {
 
       public boolean accept(File pathname) {
-        if (pathname.toString().endsWith("./pom.xml")) {
+        if (pathname.toString().endsWith("." + File.separator + "pom.xml")) {
           return true;
         }
         else {

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -260,25 +260,25 @@ public class ZipUtilTest extends TestCase {
 
     ZipFile zf = null;
     File dest = null;
-    
+
     try {
         dest = File.createTempFile("temp-stor", null);
         ZipUtil.packEntries(new File[]{file("TestFile.txt"), file("TestFile-II.txt")}, dest, Deflater.BEST_COMPRESSION);
-    	zf = new ZipFile(dest);
-	    filesizeBestCompression = zf.getEntry("TestFile.txt").getCompressedSize();
+        zf = new ZipFile(dest);
+        filesizeBestCompression = zf.getEntry("TestFile.txt").getCompressedSize();
     }finally {
-    	zf.close();
+        zf.close();
     }
-    
+
     try {
         dest = File.createTempFile("temp-stor", null);
         ZipUtil.packEntries(new File[]{file("TestFile.txt"), file("TestFile-II.txt")}, dest, Deflater.NO_COMPRESSION);
-    	zf = new ZipFile(dest);
-    	filesizeNoCompression = zf.getEntry("TestFile.txt").getCompressedSize();
+        zf = new ZipFile(dest);
+        filesizeNoCompression = zf.getEntry("TestFile.txt").getCompressedSize();
     }finally {
-    	zf.close();
+        zf.close();
     }
-    
+
     assertTrue(filesizeNoCompression > 0);
     assertTrue(filesizeBestCompression > 0);
     assertTrue(filesizeNoCompression > filesizeBestCompression);


### PR DESCRIPTION
This is [1] a new feature, [2] a correction of a naming error introduced in PR https://github.com/zeroturnaround/zt-zip/pull/62, and [3] fixes to unit tests that were failing on windows.

**1.** ZipUtils.packEntries() now receives compressionLevel (e.g., Deflater.NO_COMPRESSION) as input. Example use case: when creating a zip of zips (or other compressed files), you don't want to waste CPU cycles trying to re-compress them. A test case has been added (testPackEntriesWithCompressionLevel), and backwards compatibility is maintained.

**2.** A few methods were introduced in https://github.com/zeroturnaround/zt-zip/pull/62 that claimed to set or retrieve the compression level, when actually they were retrieving the compression method (STORE or DEFLATE). This PR corrects the method signature & variable names in such cases (backwards compatibility is maintained). 

I suspect that this wasn't caught before, since unhelpfully Java represents both the compression method and the compression level as ints, where:
- Compression level is 0-9 (0 is no compression, 9 is maximum compression).
- Compression method is 0 or 8 (0 is STORED [not compressed], 8 is DEFLATED [compressed])

(Java's use of ints here has caused confusion elsewhere, e.g., http://stackoverflow.com/questions/1206970/how-to-create-uncompressed-zip-archive-in-java )

**3.** Two unit tests were failing on Windows due to OS specific quirks. Fixed.
