### PR TITLE
Fixed same-zip bug

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -40,6 +40,7 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import com.sun.javaws.exceptions.InvalidArgumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.zip.commons.FileUtils;
@@ -2705,9 +2706,12 @@ public final class ZipUtil {
    *          transformer for the given ZIP entry.
    * @param destZip
    *          new ZIP file created.
+   * @throws IllegalArgumentException if the destination is the same as the location
    * @return <code>true</code> if the entry was replaced.
    */
   public static boolean transformEntry(File zip, String path, ZipEntryTransformer transformer, File destZip) {
+    if(zip.equals(destZip)){throw new IllegalArgumentException("Input (" +zip.getAbsolutePath()+ ") is the same as the destination!" +
+            "\nPlease use the transformEntry without destination for in-place transformation." );}
     return transformEntry(zip, new ZipEntryTransformerEntry(path, transformer), destZip);
   }
 

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -40,7 +40,6 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
-import com.sun.javaws.exceptions.InvalidArgumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.zip.commons.FileUtils;

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -2710,7 +2710,7 @@ public final class ZipUtil {
    */
   public static boolean transformEntry(File zip, String path, ZipEntryTransformer transformer, File destZip) {
     if(zip.equals(destZip)){throw new IllegalArgumentException("Input (" +zip.getAbsolutePath()+ ") is the same as the destination!" +
-            "\nPlease use the transformEntry without destination for in-place transformation." );}
+            "Please use the transformEntry method without destination for in-place transformation." );}
     return transformEntry(zip, new ZipEntryTransformerEntry(path, transformer), destZip);
   }
 

--- a/src/test/java/org/zeroturnaround/zip/ZipTransformTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipTransformTest.java
@@ -35,6 +35,21 @@ import org.zeroturnaround.zip.transform.StringZipEntryTransformer;
 
 public class ZipTransformTest extends TestCase {
 
+  public void testZipTransformNotInPlaceButSameLocation() throws IOException {
+    //Create dummy file and transformer
+    File file = File.createTempFile("temp", null);
+    StreamZipEntryTransformer arrayZipEntryTransformer = new StreamZipEntryTransformer() {
+      protected void transform(ZipEntry zipEntry, InputStream in, OutputStream out) throws IOException { }
+    };
+    try {
+      ZipUtil.transformEntry(file, "", arrayZipEntryTransformer, file);
+      //This line should not be reached.
+      assertTrue(false);
+    } catch(IllegalArgumentException e){
+      //Do nothing, test passed.
+    }
+  }
+
   public void testByteArrayTransformer() throws IOException {
     final String name = "foo";
     final byte[] contents = "bar".getBytes();


### PR DESCRIPTION
Added exception to transformEntry if the source was equal to the destination, but not in-place.

In the case that you would use transformEntry on a zip, and have the same input as output, the application would crash and it would remove all the contents of the original zip. This change ensures that you cannot call the procedure with the same file. The user is warned that it may use the same function except without a destination to achieve the same effect.