### PR TITLE
Add proguard rules for downstream consumption

### DIFF
--- a/src/main/resources/META-INF/proguard/zt-zip.pro
+++ b/src/main/resources/META-INF/proguard/zt-zip.pro
@@ -1,0 +1,4 @@
+# make sure ZipExtraField constructors are kept
+-keep class * implements org.zeroturnaround.zip.extra.ZipExtraField {
+    public <init>();
+}


### PR DESCRIPTION
We use R8 to minify one of our CLI binaries and got bit by it as R8 decided to remove the ctor from the `AsiExtraField` class, resulting in the following crash:

```
Caused by: java.lang.RuntimeException: class S0.a is not a concrete class
	at S0.b.<clinit>(SourceFile:14)
```

This commit adds Proguard rules to the library jar so downstream minifier tools can pick them up automatically.