### PR TITLE
Made the private method to add a directory to the zipoutputstream public

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1742,7 +1742,7 @@ public final class ZipUtil {
    * @param mustHaveChildren
    *          if true, but directory to pack doesn't have any files, throw an exception.
    */
-  private static void pack(File dir, ZipOutputStream out, NameMapper mapper, String pathPrefix, boolean mustHaveChildren) throws IOException {
+  public static void pack(File dir, ZipOutputStream out, NameMapper mapper, String pathPrefix, boolean mustHaveChildren) throws IOException {
     String[] filenames = dir.list();
     if (filenames == null) {
       if (!dir.exists()) {


### PR DESCRIPTION
I need this method in many situations can we make public ?

The use case:
- I have a directory file on the disk
- I have already the ZipOutputStream object form a different workflow
- if you made the method public i can just use that directly .