### PR TITLE
Improve the checks for relative traversal.

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1140,7 +1140,7 @@ public final class ZipUtil {
      * that the outputdir + name doesn't leave the outputdir. See
      * DirectoryTraversalMaliciousTest for details.
      */
-    if (name.indexOf("..") != -1 && !destFile.getCanonicalPath().startsWith(outputDir.getCanonicalPath())) {
+    if (name.indexOf("..") != -1 && !destFile.getCanonicalFile().toPath().startsWith(outputDir.getCanonicalFile().toPath())) {
       throw new MaliciousZipException(outputDir, name);
     }
     return destFile;


### PR DESCRIPTION
Use java.nio.file.Path for consistent sub-directory checking