### PR TITLE
Add regression test for sibling-prefix directory traversal

### DIFF
--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -16,6 +16,10 @@ package org.zeroturnaround.zip;
  *    limitations under the License.
  */
 import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import junit.framework.TestCase;
 
@@ -92,6 +96,38 @@ public class DirectoryTraversalMaliciousTest extends TestCase {
     }
     catch (MaliciousZipException e) {
       assertTrue(true);
+    }
+  }
+
+  /*
+   * An entry can leave the target without escaping its parent: a name like
+   * "../targetX" resolves to a sibling directory whose path shares a prefix with
+   * the target. A plain string prefix check treats that as inside the target; the
+   * traversal guard must compare path components instead.
+   */
+  public void testUnpackDoesntLeaveTargetForSiblingWithSharedPrefix() throws Exception {
+    File parent = Files.createTempDirectory("zt-zip-traversal").toFile();
+    File target = new File(parent, "target");
+    target.mkdir();
+
+    File zip = File.createTempFile("sibling-prefix-traversal", ".zip");
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      out.putNextEntry(new ZipEntry("good.txt"));
+      out.closeEntry();
+      out.putNextEntry(new ZipEntry("../targetX/evil.txt"));
+      out.closeEntry();
+    }
+    finally {
+      out.close();
+    }
+
+    try {
+      ZipUtil.unpack(zip, target);
+      fail();
+    }
+    catch (MaliciousZipException e) {
+      assertFalse(new File(parent, "targetX/evil.txt").exists());
     }
   }
 }


### PR DESCRIPTION
Follow-up to #158, which fixed a partial path-traversal bypass by switching the guard in `ZipUtil.checkDestinationFileForTraversal` from a string prefix check to `Path.startsWith`.

That fix shipped without a test, and the existing `DirectoryTraversalMaliciousTest` cases only cover entries that escape far outside the target (to `/tmp`, `/home`). They stay green even with the old string check, so nothing guards against the specific bypass #158 fixed.

This adds `testUnpackDoesntLeaveTargetForSiblingWithSharedPrefix`: a zip with an entry `../targetX/evil.txt` unpacked into `target`. The destination resolves to a sibling directory whose path shares the `target` prefix — outside the target, but accepted by a plain `String.startsWith`. The test asserts a `MaliciousZipException` and that the escaping file is not written.

Verified it fails on the pre-#158 string check and passes with the current `Path.startsWith` guard. Builds a small zip on the fly rather than adding a binary fixture.

Relates to #159, #160.