### PR TITLE
Add public pack overloads for an existing ZipOutputStream

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1729,6 +1729,58 @@ public final class ZipUtil {
   }
 
   /**
+   * Compresses the given directory and all of its sub-directories into the passed in
+   * ZIP output stream. The entries are appended to the stream as-is; it is the
+   * responsibility of the caller to finish and close the stream properly, so further
+   * entries may be written before that. An empty directory simply adds no entries.
+   * <p>
+   * Unlike the {@link OutputStream}-based {@code pack} methods, this overload propagates
+   * {@link IOException} instead of wrapping it in an unchecked {@link ZipException}, since
+   * the caller owns the stream. Pass an already-open stream to this overload rather than to
+   * the {@link OutputStream} overloads, which would nest a new archive inside the stream.
+   *
+   * @param sourceDir
+   *          root directory.
+   * @param os
+   *          open ZIP output stream the entries are written to.
+   *
+   * @throws IOException
+   *          if writing an entry to the stream fails.
+   *
+   * @since 1.18
+   */
+  public static void pack(File sourceDir, ZipOutputStream os) throws IOException {
+    pack(sourceDir, os, IdentityNameMapper.INSTANCE);
+  }
+
+  /**
+   * Compresses the given directory and all of its sub-directories into the passed in
+   * ZIP output stream. The entries are appended to the stream as-is; it is the
+   * responsibility of the caller to finish and close the stream properly, so further
+   * entries may be written before that. An empty directory simply adds no entries.
+   * <p>
+   * Unlike the {@link OutputStream}-based {@code pack} methods, this overload propagates
+   * {@link IOException} instead of wrapping it in an unchecked {@link ZipException}, since
+   * the caller owns the stream. Pass an already-open stream to this overload rather than to
+   * the {@link OutputStream} overloads, which would nest a new archive inside the stream.
+   *
+   * @param sourceDir
+   *          root directory.
+   * @param os
+   *          open ZIP output stream the entries are written to.
+   * @param mapper
+   *          call-back for renaming the entries.
+   *
+   * @throws IOException
+   *          if writing an entry to the stream fails.
+   *
+   * @since 1.18
+   */
+  public static void pack(File sourceDir, ZipOutputStream os, NameMapper mapper) throws IOException {
+    pack(sourceDir, os, mapper, "", false);
+  }
+
+  /**
    * Compresses the given directory and all its sub-directories into a ZIP file.
    *
    * @param dir

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -926,4 +926,94 @@ public class ZipUtilTest extends TestCase {
     // As the ZIP file is empty then the unpack doesn't create the directory.
     // So this is why I don't have a forceDelete for the dest variable - FileUtils.forceDelete(dest);
   }
+
+  public void testPackDirIntoExistingZipOutputStream() throws Exception {
+    File zip = File.createTempFile("pack-into-stream", ".zip");
+
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      // an entry written by the caller's own workflow before packing the directory
+      out.putNextEntry(new ZipEntry("manual.txt"));
+      out.write("manual".getBytes("UTF-8"));
+      out.closeEntry();
+
+      // the caller owns the stream; pack appends the directory's contents into it
+      ZipUtil.pack(new File("src/test/resources/testDirectory"), out);
+
+      // pack must not have finished the stream: the caller can keep appending
+      out.putNextEntry(new ZipEntry("after.txt"));
+      out.write("after".getBytes("UTF-8"));
+      out.closeEntry();
+    }
+    finally {
+      out.close();
+    }
+
+    assertTrue(ZipUtil.containsEntry(zip, "manual.txt"));
+    assertTrue(ZipUtil.containsEntry(zip, "after.txt"));
+    assertTrue(ZipUtil.containsEntry(zip, "testfileInTestDirectory.txt"));
+    assertTrue(ZipUtil.containsEntry(zip, "testSubdirectory/"));
+    assertTrue(ZipUtil.containsEntry(zip, "testSubdirectory/testFileInTestSubdirectory.txt"));
+
+    assertEquals("manual", new String(ZipUtil.unpackEntry(zip, "manual.txt"), "UTF-8"));
+    assertEquals("after", new String(ZipUtil.unpackEntry(zip, "after.txt"), "UTF-8"));
+    assertEquals("badabing", new String(ZipUtil.unpackEntry(zip, "testfileInTestDirectory.txt"), "UTF-8"));
+    assertEquals("badaboom", new String(ZipUtil.unpackEntry(zip, "testSubdirectory/testFileInTestSubdirectory.txt"), "UTF-8"));
+
+    FileUtils.forceDelete(zip);
+  }
+
+  public void testPackDirIntoExistingZipOutputStreamWithNameMapper() throws Exception {
+    File zip = File.createTempFile("pack-into-stream-mapper", ".zip");
+
+    NameMapper prefixMapper = new NameMapper() {
+      public String map(String name) {
+        return "renamed/" + name;
+      }
+    };
+
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      ZipUtil.pack(new File("src/test/resources/testDirectory"), out, prefixMapper);
+    }
+    finally {
+      out.close();
+    }
+
+    assertTrue(ZipUtil.containsEntry(zip, "renamed/testfileInTestDirectory.txt"));
+    assertTrue(ZipUtil.containsEntry(zip, "renamed/testSubdirectory/testFileInTestSubdirectory.txt"));
+    assertFalse(ZipUtil.containsEntry(zip, "testfileInTestDirectory.txt"));
+
+    FileUtils.forceDelete(zip);
+  }
+
+  public void testPackEmptyDirIntoExistingZipOutputStream() throws Exception {
+    File emptyDir = File.createTempFile("empty-dir", null);
+    assertTrue(emptyDir.delete());
+    assertTrue(emptyDir.mkdir());
+    File zip = File.createTempFile("pack-empty-into-stream", ".zip");
+
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      out.putNextEntry(new ZipEntry("manual.txt"));
+      out.closeEntry();
+      // an empty directory must be a no-op, not a ZipException
+      ZipUtil.pack(emptyDir, out);
+    }
+    finally {
+      out.close();
+    }
+
+    assertTrue(ZipUtil.containsEntry(zip, "manual.txt"));
+    ZipFile zf = new ZipFile(zip);
+    try {
+      assertEquals(1, zf.size());
+    }
+    finally {
+      zf.close();
+    }
+
+    FileUtils.forceDelete(emptyDir);
+    FileUtils.forceDelete(zip);
+  }
 }


### PR DESCRIPTION
Alternative to #154.

#154 requests a way to append a directory to a `ZipOutputStream` the caller already holds, and does it by making the private recursive `pack(File, ZipOutputStream, NameMapper, String, boolean)` worker public. That works, but it leaks two implementation-detail parameters into the permanent API: `pathPrefix` (the recursion accumulator — callers would always pass `""`) and `mustHaveChildren` (an internal "throw on empty dir" flag). It also exposes the worker without documenting that it doesn't finish/flush the stream.

This adds two narrow public overloads instead:

```java
public static void pack(File sourceDir, ZipOutputStream os)
public static void pack(File sourceDir, ZipOutputStream os, NameMapper mapper)
```

- Both delegate to the existing private worker with an empty path prefix, so `pathPrefix`/`mustHaveChildren` stay private.
- The no-mapper overload supplies the identity mapper (package-private, not reachable by external callers), mirroring the existing `pack(File, OutputStream, ...)` family.
- Javadoc states that finishing/closing the stream is the caller's responsibility (so further entries may be appended), and that — unlike the other `pack` methods — `IOException` is propagated rather than wrapped in an unchecked `ZipException`, since the caller owns the stream. It also notes to use this overload rather than passing a `ZipOutputStream` as an `OutputStream` (which would nest a new archive).

Tests in `ZipUtilTest`:
- `testPackDirIntoExistingZipOutputStream` — writes a caller entry, packs a directory into the same stream, writes another entry **after** `pack` (proving the stream isn't finished), and verifies entry presence **and contents**.
- `testPackDirIntoExistingZipOutputStreamWithNameMapper` — covers the mapper overload.
- `testPackEmptyDirIntoExistingZipOutputStream` — verifies an empty directory is a no-op (no exception, no entries), exercising the `mustHaveChildren=false` path.

Closes the need behind #154 without widening the API surface.