### PR TITLE
Create temp directories with Files.createTempDirectory

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/Zips.java
+++ b/src/main/java/org/zeroturnaround/zip/Zips.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -387,10 +388,7 @@ public class Zips {
   private File getDestinationFile() throws IOException {
     if(isUnpack()) {
       if(isInPlace()) {
-        File tempFile = File.createTempFile("zips", null);
-        FileUtils.deleteQuietly(tempFile);
-        tempFile.mkdirs(); // temp dir created
-        return tempFile;
+        return Files.createTempDirectory("zips").toFile();
       }
       else {
         if (!dest.isDirectory()) {

--- a/src/test/java/org/zeroturnaround/zip/FilePermissionsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/FilePermissionsTest.java
@@ -16,6 +16,7 @@ package org.zeroturnaround.zip;
  */
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Assume;
 import org.zeroturnaround.zip.commons.FileUtils;
@@ -31,9 +32,7 @@ public class FilePermissionsTest {
   public void testPreserveExecuteFlag() throws Exception {
     String dirName = "FilePermissionsTest-e";
 
-    File tmpDir = File.createTempFile(dirName, null);
-    tmpDir.delete();
-    tmpDir.mkdir();
+    File tmpDir = Files.createTempDirectory(dirName).toFile();
     File fileA = new File(tmpDir, "fileA.txt");
     File fileB = new File(tmpDir, "fileB.txt");
     FileUtils.copyFile(testFile, fileA);
@@ -62,9 +61,7 @@ public class FilePermissionsTest {
   public void testPreserveReadFlag() throws Exception {
     String dirName = "FilePermissionsTest-r";
 
-    File tmpDir = File.createTempFile(dirName, null);
-    tmpDir.delete();
-    tmpDir.mkdir();
+    File tmpDir = Files.createTempDirectory(dirName).toFile();
     File fileA = new File(tmpDir, "fileA.txt");
     File fileB = new File(tmpDir, "fileB.txt");
     FileUtils.copyFile(testFile, fileA);
@@ -95,9 +92,7 @@ public class FilePermissionsTest {
   public void testPreserveWriteFlag() throws Exception {
     String dirName = "FilePermissionsTest-w";
 
-    File tmpDir = File.createTempFile(dirName, null);
-    tmpDir.delete();
-    tmpDir.mkdir();
+    File tmpDir = Files.createTempDirectory(dirName).toFile();
     File fileA = new File(tmpDir, "fileA.txt");
     File fileB = new File(tmpDir, "fileB.txt");
     FileUtils.copyFile(testFile, fileA, true);

--- a/src/test/java/org/zeroturnaround/zip/MainExamplesTest.java
+++ b/src/test/java/org/zeroturnaround/zip/MainExamplesTest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 
 import junit.framework.TestCase;
@@ -52,9 +53,7 @@ public final class MainExamplesTest extends TestCase {
   }
 
   public static void testUnpack() throws IOException {
-    File tmpDir = File.createTempFile("prefix", "suffix");
-    tmpDir.delete();
-    tmpDir.mkdir();
+    File tmpDir = Files.createTempDirectory("prefixsuffix").toFile();
     ZipUtil.unpack(new File(DEMO_ZIP), tmpDir);
     File fooFile = new File(tmpDir, FOO_TXT);
     assertTrue(fooFile.exists());
@@ -62,9 +61,7 @@ public final class MainExamplesTest extends TestCase {
 
   public static void testUnpackInPlace() throws Exception{
     File demoFile = new File(DEMO_ZIP);
-    File outDir = File.createTempFile("prefix", "suffix");
-    outDir.delete();
-    outDir.mkdir();
+    File outDir = Files.createTempDirectory("prefixsuffix").toFile();
 
     File outFile = new File(outDir, "demo");
     FileOutputStream fio = new FileOutputStream(outFile);

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -687,10 +688,8 @@ public class ZipUtilTest extends TestCase {
 
   public void testUnwrapFile() throws Exception {
     File dest = File.createTempFile("temp", null);
-    File destDir = File.createTempFile("tempDir", null);
+    File destDir = Files.createTempDirectory("tempDir").toFile();
     try {
-      destDir.delete();
-      destDir.mkdir();
       String child = "TestFile.txt";
       File parent = file(child).getParentFile();
       ZipUtil.pack(parent, dest, true);
@@ -704,11 +703,9 @@ public class ZipUtilTest extends TestCase {
 
   public void testUnwrapStream() throws Exception {
     File dest = File.createTempFile("temp", null);
-    File destDir = File.createTempFile("tempDir", null);
+    File destDir = Files.createTempDirectory("tempDir").toFile();
     InputStream is = null;
     try {
-      destDir.delete();
-      destDir.mkdir();
       String child = "TestFile.txt";
       File parent = file(child).getParentFile();
       ZipUtil.pack(parent, dest, true);
@@ -724,10 +721,8 @@ public class ZipUtilTest extends TestCase {
 
   public void testUnwrapEntriesInRoot() throws Exception {
     File src = file("demo.zip");
-    File destDir = File.createTempFile("tempDir", null);
+    File destDir = Files.createTempDirectory("tempDir").toFile();
     try {
-      destDir.delete();
-      destDir.mkdir();
       ZipUtil.unwrap(src, destDir);
       fail("expected a ZipException, unwrapping with multiple roots is not supported");
     }
@@ -741,10 +736,8 @@ public class ZipUtilTest extends TestCase {
 
   public void testUnwrapMultipleRoots() throws Exception {
     File src = file("demo-dirs-only.zip");
-    File destDir = File.createTempFile("tempDir", null);
+    File destDir = Files.createTempDirectory("tempDir").toFile();
     try {
-      destDir.delete();
-      destDir.mkdir();
       ZipUtil.unwrap(src, destDir);
       fail("expected a ZipException, unwrapping with multiple roots is not supported");
     }
@@ -758,10 +751,8 @@ public class ZipUtilTest extends TestCase {
 
   public void testUnwrapSingleRootWithStructure() throws Exception {
     File src = file("demo-single-root-dir.zip");
-    File destDir = File.createTempFile("tempDir", null);
+    File destDir = Files.createTempDirectory("tempDir").toFile();
     try {
-      destDir.delete();
-      destDir.mkdir();
       ZipUtil.unwrap(src, destDir);
       assertTrue((new File(destDir, "b.txt")).exists());
       assertTrue((new File(destDir, "bad.txt")).exists());
@@ -775,10 +766,8 @@ public class ZipUtilTest extends TestCase {
 
   public void testUnwrapEmptyRootDir() throws Exception {
     File src = file("demo-single-empty-root-dir.zip");
-    File destDir = File.createTempFile("tempDir", null);
+    File destDir = Files.createTempDirectory("tempDir").toFile();
     try {
-      destDir.delete();
-      destDir.mkdir();
       ZipUtil.unwrap(src, destDir);
       assertTrue("Dest dir should be empty, root dir was shaved", destDir.list().length == 0);
     }
@@ -884,16 +873,8 @@ public class ZipUtilTest extends TestCase {
   public void testUnpackBackslashes() throws IOException {
     File initialSrc = file("backSlashTest.zip");
 
-    // lets create a temporary file and then use it as a dir
-    File dest = File.createTempFile("unpackEntryDir", null);
-
-    if(!(dest.delete())) {
-        throw new IOException("Could not delete temp file: " + dest.getAbsolutePath());
-    }
-
-    if(!(dest.mkdir())){
-        throw new IOException("Could not create temp directory: " + dest.getAbsolutePath());
-    }
+    // create a temporary directory to unpack into
+    File dest = Files.createTempDirectory("unpackEntryDir").toFile();
 
     // unpack the archive that has the backslashes
     // and double check that the file structure is preserved
@@ -988,9 +969,7 @@ public class ZipUtilTest extends TestCase {
   }
 
   public void testPackEmptyDirIntoExistingZipOutputStream() throws Exception {
-    File emptyDir = File.createTempFile("empty-dir", null);
-    assertTrue(emptyDir.delete());
-    assertTrue(emptyDir.mkdir());
+    File emptyDir = Files.createTempDirectory("empty-dir").toFile();
     File zip = File.createTempFile("pack-empty-into-stream", ".zip");
 
     ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));

--- a/src/test/java/org/zeroturnaround/zip/ZipsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipsTest.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -558,9 +559,7 @@ public class ZipsTest extends TestCase {
 
   public void testUnpackImplicit() throws IOException {
     File original = new File(MainExamplesTest.DEMO_ZIP);
-    final File dest = File.createTempFile("temp", null);
-    FileUtils.deleteQuietly(dest);
-    dest.mkdirs();
+    final File dest = Files.createTempDirectory("temp").toFile();
     Zips.get(original).destination(dest).process();
     assertTrue(dest.isDirectory());
     ZipUtil.iterate(original, new ZipInfoCallback() {


### PR DESCRIPTION
Supersedes #147.

#147 (an automated security-research PR from 2022) flagged the insecure temp-directory idiom:

```java
File d = File.createTempFile(x, null);  d.delete();  d.mkdir();
```

This is the temporary-directory hijacking / information-disclosure pattern (CWE-377/CWE-379): the path is predictable, the `mkdir()` return value is sometimes unchecked, and the directory is created with the default (world-readable) umask. `Files.createTempDirectory(...)` creates the directory atomically with owner-only permissions instead.

### Shipped code

#147 only touched tests and **missed the one place the idiom actually ships**: `Zips.getDestinationFile()`, the in-place unpack path, created its working temp directory this way. That's fixed here:

```java
// before
File tempFile = File.createTempFile("zips", null);
FileUtils.deleteQuietly(tempFile);
tempFile.mkdirs();
return tempFile;
// after
return Files.createTempDirectory("zips").toFile();
```

It's covered by the existing in-place unpack test (`ZipsTest` `Zips.get(src).unpack().process()`).

### Tests

The same idiom is swept across the test suite (13 sites): `FilePermissionsTest` (3), `MainExamplesTest` (2), `ZipsTest` (1), `ZipUtilTest` (7, incl. the `backSlashTest` block and the empty-dir test). `Files.createTempDirectory` throws `IOException` on failure, which is the same as — or stricter than — the previous (mostly unchecked) `mkdir()` calls, so behaviour is preserved.

Left intentionally unchanged (not the vulnerable idiom): `ZipUtilTest.testUnexplode` (deliberately creates a directory with the same name as a just-deleted temp file to exercise `unexplode`) and `DirectoryTraversalMaliciousTest` (its `target` subdir lives inside an already-secure `Files.createTempDirectory` parent).

All 124 tests pass.