### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately rather than opening a public issue.
+
+Use GitHub's private vulnerability reporting: open the
+[Security tab](https://github.com/zeroturnaround/zt-zip/security) and click
+**"Report a vulnerability"**. This creates a private advisory visible only to
+you and the maintainers.
+
+We aim to acknowledge reports within a few working days and will keep you
+informed as we investigate and prepare a fix. When a fix is released we publish
+a security advisory and credit the reporter unless you prefer to remain anonymous.
+
+## Supported Versions
+
+Security fixes are made against the latest released version. Please make sure you
+are on the most recent release before reporting an issue.


### PR DESCRIPTION
Adds `.github/SECURITY.md` so the repository has a documented vulnerability-reporting process, as requested in #157.

It points reporters at GitHub's **private vulnerability reporting** ("Report a vulnerability" in the Security tab), which has now been enabled on the repository, so they have a private channel instead of opening a public issue (as happened in #159 / #160).

Supported-versions guidance is kept as "the latest release" rather than a version table, so it doesn't go stale.

Closes #157.