### PR TITLE
Fix Stream closed error when adding a directory FileSource

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/FileSource.java
+++ b/src/main/java/org/zeroturnaround/zip/FileSource.java
@@ -42,8 +42,13 @@ public class FileSource implements ZipEntrySource {
   }
 
   public ZipEntry getEntry() {
-    ZipEntry entry = ZipEntryUtil.fromFile(path, file);
-    return entry;
+    // A directory must be represented by an entry whose name ends with "/", otherwise
+    // it would be stored as an empty regular file rather than a directory.
+    String name = path;
+    if (file.isDirectory() && !name.endsWith("/")) {
+      name = name + "/";
+    }
+    return ZipEntryUtil.fromFile(name, file);
   }
 
   public InputStream getInputStream() throws IOException {

--- a/src/main/java/org/zeroturnaround/zip/ZipEntryUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipEntryUtil.java
@@ -112,7 +112,10 @@ class ZipEntryUtil {
       copy.setTime(System.currentTimeMillis());
     }
     
-    addEntry(copy, new BufferedInputStream(in), out);
+    // A null stream means the entry has no content (e.g. a directory entry). Keep it
+    // null so addEntry skips the copy; wrapping it in a BufferedInputStream would make
+    // it non-null and the copy would fail with "Stream closed".
+    addEntry(copy, in == null ? null : new BufferedInputStream(in), out);
   }
 
   /**

--- a/src/test/java/org/zeroturnaround/zip/ZipsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipsTest.java
@@ -62,6 +62,69 @@ public class ZipsTest extends TestCase {
     assertTrue(ZipUtil.containsEntry(dest, fileName));
   }
 
+  public void testAddDirectoryEntry() throws IOException {
+    assertDirectorySourceAddsDirectoryEntry("somedir", true);
+  }
+
+  public void testAddDirectoryEntryWithTrailingSlash() throws IOException {
+    assertDirectorySourceAddsDirectoryEntry("somedir/", true);
+  }
+
+  public void testAddEmptyDirectoryEntry() throws IOException {
+    assertDirectorySourceAddsDirectoryEntry("somedir", false);
+  }
+
+  /**
+   * Adds a directory {@link FileSource} under the given path and asserts it lands as the
+   * directory entry "somedir/" (regardless of whether the caller's path had a trailing slash).
+   *
+   * @param sourcePath the path passed to the FileSource
+   * @param withChild whether the directory should contain a child file
+   */
+  private void assertDirectorySourceAddsDirectoryEntry(String sourcePath, boolean withChild) throws IOException {
+    File dir = Files.createTempDirectory("ztzip").toFile();
+    File dest = File.createTempFile("temp", ".zip");
+    try {
+      if (withChild) {
+        new File(dir, "child.txt").createNewFile();
+      }
+
+      Zips.create().destination(dest).addEntry(new FileSource(sourcePath, dir)).process();
+
+      assertTrue("Result zip misses directory entry 'somedir/'", ZipUtil.containsEntry(dest, "somedir/"));
+    }
+    finally {
+      FileUtils.deleteQuietly(dir);
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
+  public void testAddDirectoryAndFileEntries() throws IOException {
+    File dir = Files.createTempDirectory("ztzip").toFile();
+    File dest = File.createTempFile("temp", ".zip");
+    try {
+      new File(dir, "child.txt").createNewFile();
+
+      // An existing regular file added alongside the directory: a directory source has a
+      // null stream while a file source has real content, so this proves the directory fix
+      // does not break a normal file entry and that both kinds of entry coexist in one zip.
+      String fileName = "TestFile.txt";
+      File file = new File("src/test/resources/" + fileName);
+
+      Zips.create().destination(dest)
+          .addEntry(new FileSource("somedir", dir))
+          .addEntry(new FileSource(fileName, file))
+          .process();
+
+      assertTrue("Result zip misses directory entry 'somedir/'", ZipUtil.containsEntry(dest, "somedir/"));
+      assertTrue("Result zip misses file entry '" + fileName + "'", ZipUtil.containsEntry(dest, fileName));
+    }
+    finally {
+      FileUtils.deleteQuietly(dir);
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
   public void testRemoveEntry() throws IOException {
     File src = new File(MainExamplesTest.DEMO_ZIP);
 


### PR DESCRIPTION
Fixes #138

## Problem

`Zips.addEntry` / `addEntries` with a `FileSource` that points at a directory throws:

```
org.zeroturnaround.zip.ZipException: java.io.IOException: Stream closed
```

Minimal repro:

```java
File dir = Files.createTempDirectory("d").toFile();
new File(dir, "child.txt").createNewFile();
Zips.create().destination(File.createTempFile("out", ".zip"))
    .addEntry(new FileSource("somedir", dir))   // also failed with "somedir/"
    .process();
```

## Root cause

`FileSource.getInputStream()` returns `null` for a directory — which the `ZipEntrySource` interface explicitly documents ("or `null` if this entry is a directory"). `ZipEntryUtil.addEntry(ZipEntry, InputStream, ZipOutputStream)` is already null-safe and skips the content copy when the stream is `null`.

But `ZipEntryUtil.copyEntry` (used by the `Zips` add path via `CopyingCallback`) wrapped the stream in `new BufferedInputStream(in)` **before** the null check. A `BufferedInputStream` wrapping a `null` underlying stream is itself non-null, so `addEntry` no longer skipped the copy and `IOUtils.copy` read from it — which throws `IOException: Stream closed` (the buffered stream's null-underlying-stream guard).

## Fix

- `ZipEntryUtil.copyEntry`: keep a `null` stream `null` so `addEntry` skips the copy, exactly as the sibling `addEntry(ZipEntrySource, ...)` path (`ZipUtil.java`) already did. This makes `copyEntry` honor the documented `ZipEntrySource` contract; verified that none of the other `copyEntry` callers (repack/copy/replace over an existing zip) ever pass a `null` stream for directory entries, so their behavior is unchanged.
- `FileSource.getEntry()`: a directory must be represented by an entry whose name ends with `/`, otherwise it is stored as an empty regular file. The entry name is now normalized to end with `/` for a directory when the caller's path does not already have one (so both `"somedir"` and `"somedir/"` produce the directory entry `somedir/`, with no double slash).

A `FileSource` represents exactly one entry, so adding a directory source adds only the directory entry, not its contents — recursive directory packing remains the separate `ZipUtil.pack` API. This is unchanged.

## Tests

Added to `ZipsTest`: `testAddDirectoryEntry`, `testAddDirectoryEntryWithTrailingSlash`, `testAddEmptyDirectoryEntry`, and `testAddDirectoryAndFileEntries` (directory + file coexisting). They **fail on master** with `IOException: Stream closed` and **pass with this fix**. Full suite green.