### PR TITLE
Skip broken symbolic links when packing a directory

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1810,6 +1810,13 @@ public final class ZipUtil {
     for (int i = 0; i < filenames.length; i++) {
       String filename = filenames[i];
       File file = new File(dir, filename);
+      if (!file.exists()) {
+        // A broken (dangling) symbolic link is listed by dir.list() but cannot be read.
+        // Skip it so packing doesn't crash with a FileNotFoundException. Preserving the
+        // link itself is a separate feature and out of scope here.
+        log.debug("Skipping '{}' as it does not exist (e.g. a broken symbolic link).", file);
+        continue;
+      }
       boolean isDir = file.isDirectory();
       String path = pathPrefix + file.getName(); // NOSONAR
       if (isDir) {

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -995,4 +995,57 @@ public class ZipUtilTest extends TestCase {
     FileUtils.forceDelete(emptyDir);
     FileUtils.forceDelete(zip);
   }
+
+  public void testPackDirectoryWithBrokenSymlink() throws Exception {
+    File dir = Files.createTempDirectory("broken-symlink").toFile();
+    File zip = File.createTempFile("broken-symlink", ".zip");
+    try {
+      // Each name is both the file's path relative to the packed directory and the entry
+      // name it is expected to (not) have in the archive, so setup and assertions line up.
+      String goodEntry = "good.txt";
+      String linkEntry = "link.txt";
+      String targetEntry = "target.txt";
+      String subGoodEntry = "sub/subgood.txt";
+      String subLinkEntry = "sub/sublink.txt";
+      String subTargetEntry = "sub/subtarget.txt";
+
+      // A good file plus a symlink whose target we will delete, leaving the link dangling.
+      new File(dir, goodEntry).createNewFile();
+      File target = new File(dir, targetEntry);
+      target.createNewFile();
+      try {
+        Files.createSymbolicLink(new File(dir, linkEntry).toPath(), target.toPath());
+      }
+      catch (UnsupportedOperationException | IOException e) {
+        // This environment cannot create symbolic links (e.g. Windows without the required
+        // privilege), so the broken-link scenario cannot be exercised here. Skip the test.
+        return;
+      }
+
+      // The same arrangement nested in a subdirectory exercises the recursive pack path too.
+      new File(dir, "sub").mkdir();
+      new File(dir, subGoodEntry).createNewFile();
+      File subTarget = new File(dir, subTargetEntry);
+      subTarget.createNewFile();
+      Files.createSymbolicLink(new File(dir, subLinkEntry).toPath(), subTarget.toPath());
+
+      // Break both links: dir.list() still reports them but the files no longer exist.
+      FileUtils.forceDelete(target);
+      FileUtils.forceDelete(subTarget);
+
+      // Packing must not crash on the dangling links (issue #122).
+      ZipUtil.pack(dir, zip);
+
+      assertTrue("Result zip misses entry '" + goodEntry + "'", ZipUtil.containsEntry(zip, goodEntry));
+      assertTrue("Result zip misses entry '" + subGoodEntry + "'", ZipUtil.containsEntry(zip, subGoodEntry));
+      assertFalse("Result zip still contains broken symlink '" + linkEntry + "'", ZipUtil.containsEntry(zip, linkEntry));
+      assertFalse("Result zip still contains deleted target '" + targetEntry + "'", ZipUtil.containsEntry(zip, targetEntry));
+      assertFalse("Result zip still contains broken symlink '" + subLinkEntry + "'", ZipUtil.containsEntry(zip, subLinkEntry));
+      assertFalse("Result zip still contains deleted target '" + subTargetEntry + "'", ZipUtil.containsEntry(zip, subTargetEntry));
+    }
+    finally {
+      FileUtils.deleteQuietly(dir);
+      FileUtils.deleteQuietly(zip);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #122

## Problem

Packing a directory that contains a broken (dangling) symbolic link throws `java.io.FileNotFoundException`.

Repro (Unix):

```
touch target
ln -s target link
# pack the dir  -> ok
rm target
# pack the dir again  -> FileNotFoundException
```

## Root cause

The private recursive pack worker `pack(File dir, ZipOutputStream out, NameMapper mapper, String pathPrefix, boolean mustHaveChildren)` lists the directory with `dir.list()`, which still reports a dangling symlink, then for each name does `new File(dir, filename)` and `FileUtils.copy(file, out)`. A broken link has `File.exists() == false`, so the copy fails with `FileNotFoundException`.

## Fix

The pack worker now skips entries that do not exist (logging at `debug`) before building the entry or copying content, so packing no longer crashes:

```java
if (!file.exists()) {
  log.debug("Skipping '{}' as it does not exist (e.g. a broken symbolic link).", file);
  continue;
}
```

`File.exists()` follows symbolic links, so **valid** links continue to be packed exactly as before (by copying their target's content); only genuinely dangling links (or a file that vanishes mid-walk) are skipped. All directory-pack overloads funnel through this single worker, so the recursive case is covered too.

## Scope

This is **crash-avoidance only**. Full symbolic-link preservation (recreating links on unpack) is a separate, larger feature and is intentionally not addressed here.

Note: `packEntries`/`packEntry` (which pack an explicit, caller-supplied list of files rather than entries discovered by directory traversal) are left unchanged — a missing file in an explicitly-provided list is plausibly a caller error worth surfacing, and is outside the scope of this issue.

## Tests

Added `ZipUtilTest.testPackDirectoryWithBrokenSymlink`. Rather than guessing the OS, it probes the actual capability: it attempts `Files.createSymbolicLink` and skips the test (returns) if the environment cannot create symbolic links (`UnsupportedOperationException`, or a `FileSystemException`/`IOException` such as Windows-without-privilege). The test creates good files plus dangling symlinks both at the top level and in a subdirectory (to exercise the recursive path), then packs and asserts no crash, the good files are present, and the broken links / deleted targets are absent. It **fails on master** with `FileNotFoundException` and **passes with this fix**. Full suite green.