### PR TITLE
Adopt vMAJOR.MINOR.PATCH release tags and automate the release process

### DIFF
--- a/.github/scripts/prepare-changelog-release.sh
+++ b/.github/scripts/prepare-changelog-release.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Promote the "Unreleased" section of CHANGELOG.md into a dated release section
+# and update the comparison links at the bottom of the file. Run by the Release
+# workflow; can also be run by hand before a release.
+#
+# Usage: prepare-changelog-release.sh <version>
+#   e.g. prepare-changelog-release.sh 1.18.0
+#
+# The release date is today's date in UTC and the release tag is "v<version>",
+# matching the tag the Release workflow creates.
+set -euo pipefail
+
+version="${1:?usage: prepare-changelog-release.sh <version>}"
+changelog="CHANGELOG.md"
+date="$(date -u +%Y-%m-%d)"
+new_tag="v${version}"
+
+# The "[Unreleased]" link encodes the previous release tag as the base of its
+# compare range, e.g. ".../compare/zt-zip-1.17...HEAD" -> previous tag zt-zip-1.17.
+unreleased_link="$(grep -E '^\[Unreleased\]:' "$changelog" || true)"
+base_url="$(printf '%s\n' "$unreleased_link" | sed -E 's#^\[Unreleased\]: (https?://[^ ]+)/compare/.*#\1#')"
+prev_tag="$(printf '%s\n' "$unreleased_link" | sed -E 's#^.*/compare/(.+)\.\.\.HEAD$#\1#')"
+
+if [ -z "$base_url" ] || [ -z "$prev_tag" ] || [ "$base_url" = "$unreleased_link" ]; then
+  echo "Could not parse the [Unreleased] comparison link in $changelog" >&2
+  exit 1
+fi
+
+# Refuse to release an empty Unreleased section.
+if ! awk '
+    /^## \[Unreleased\]/ { in_section = 1; next }
+    /^## \[/             { in_section = 0 }
+    in_section && /[^[:space:]]/ { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$changelog"; then
+  echo "The [Unreleased] section is empty; nothing to release." >&2
+  exit 1
+fi
+
+awk -v version="$version" -v date="$date" -v new_tag="$new_tag" \
+    -v prev_tag="$prev_tag" -v base_url="$base_url" '
+  # Keep the (now empty) Unreleased header and open a dated section below it.
+  /^## \[Unreleased\]/ {
+    print
+    print ""
+    print "## [" version "] - " date
+    next
+  }
+  # Rewrite the Unreleased compare link and add the new release link below it.
+  /^\[Unreleased\]:/ {
+    print "[Unreleased]: " base_url "/compare/" new_tag "...HEAD"
+    print "[" version "]: " base_url "/compare/" prev_tag "..." new_tag
+    next
+  }
+  { print }
+' "$changelog" > "$changelog.tmp"
+
+mv "$changelog.tmp" "$changelog"
+echo "Promoted Unreleased to [$version] - $date (tag $new_tag, previous $prev_tag)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., 1.18)'
+        description: 'Release version (e.g., 1.18.0)'
         required: true
         type: string
 
@@ -47,6 +47,9 @@ jobs:
           # Maven coordinate snippet: <artifactId>zt-zip</artifactId> ... <version>VERSION</version>
           perl -0pi -e 's{(<artifactId>zt-zip</artifactId>\s*<version>)[^<]+}{${1}${{ inputs.version }}}g' README.md
 
+      - name: Promote changelog Unreleased section
+        run: bash .github/scripts/prepare-changelog-release.sh "${{ inputs.version }}"
+
       - name: Run full build (validates everything compiles + tests pass)
         run: ./gradlew clean build
 
@@ -60,29 +63,29 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git add build.gradle.kts README.md
+          git add build.gradle.kts README.md CHANGELOG.md
           git commit -m "Release ${{ inputs.version }}"
 
       - name: Tag and push
         run: |
-          git tag "zt-zip-${{ inputs.version }}"
+          git tag "v${{ inputs.version }}"
           git push origin HEAD
-          git push origin "zt-zip-${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "zt-zip-${{ inputs.version }}" \
-            --title "zt-zip-${{ inputs.version }}" \
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
             --generate-notes \
             build/libs/*.jar
 
       - name: Set next development version
         run: |
           VERSION="${{ inputs.version }}"
-          # Increment the last numeric component, matching the historical
-          # versioning (1.18 -> 1.19; 1.18.1 -> 1.18.2).
+          # Increment the last numeric component to the next patch development
+          # version (1.18.0 -> 1.18.1); bump the minor or major by hand when needed.
           PREFIX="${VERSION%.*}"
           LAST="${VERSION##*.}"
           if [ "$PREFIX" = "$VERSION" ]; then

--- a/README.md
+++ b/README.md
@@ -284,6 +284,21 @@ Gradle installation is required:
 The library targets Java 8 bytecode. The build resolves a Java 8 toolchain automatically (it is
 downloaded on demand if not already installed), so the build itself runs on any modern JDK.
 
+## Releasing
+
+Versions follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`, e.g. `1.18.0`)
+and release tags use the `vMAJOR.MINOR.PATCH` form (e.g. `v1.18.0`). Tags created before this
+convention use the older `zt-zip-<version>` form.
+
+Releases are cut with the **Release** GitHub Actions workflow (Actions → Release → Run workflow).
+It takes the release version (e.g. `1.18.0`) and then builds, publishes to Maven Central, tags
+the commit, creates the GitHub release, and sets the next development version.
+
+The workflow also promotes the `## [Unreleased]` section of [CHANGELOG.md](CHANGELOG.md) into a
+dated `## [x.y.z]` section and updates the comparison links, so the only changelog task is to make
+sure the changes being released are listed under `## [Unreleased]` beforehand. (The release fails
+if that section is empty.)
+
 ## Progress bar
 
 There have been multiple requests for a progress bar. See [ZT Zip Progress Bar](https://github.com/toomasr/zt-zip-progress-bar) for a

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 }
 
 group = "org.zeroturnaround"
-version = "1.18-SNAPSHOT"
+version = "1.18.0-SNAPSHOT"
 description =
   "The project is intended to have a small, easy and fast library to process ZIP archives. " +
     "Either create, modify or explode them. On disk or in memory."


### PR DESCRIPTION
Adopts [Semantic Versioning](https://semver.org/) three-part versions and `vMAJOR.MINOR.PATCH` release tags going forward, and automates the changelog promotion during release.

## Changes

- **`build.gradle.kts`**: development version `1.18-SNAPSHOT` → `1.18.0-SNAPSHOT` (next release is `1.18.0`).
- **`.github/workflows/release.yml`**:
  - Tag and GitHub release are now named `v<version>` (e.g. `v1.18.0`) instead of `zt-zip-<version>`.
  - New step runs `prepare-changelog-release.sh`, and the release commit now also includes `CHANGELOG.md`.
  - `version` input example and the next-dev-version comment updated.
- **`.github/scripts/prepare-changelog-release.sh`** (new): promotes the changelog for a release — moves the `## [Unreleased]` entries into a `## [x.y.z] - YYYY-MM-DD` section, rewrites the `[Unreleased]` comparison link to `v<version>...HEAD`, and inserts the new `[x.y.z]` comparison link. Derives the previous tag from the existing `[Unreleased]` link, so the first release links back to `zt-zip-1.17` and subsequent ones link between `v<version>` tags. Fails the release if the Unreleased section is empty.
- **`README.md`**: new **Releasing** section documenting the tag convention and the workflow; the changelog promotion is now automatic, so the only manual step is listing changes under `## [Unreleased]`.

## Verification

Ran the script locally against the current `CHANGELOG.md`:
- `1.18.0` → creates `## [1.18.0] - <date>`, leaves `## [Unreleased]` empty, sets `[Unreleased]: …/compare/v1.18.0...HEAD` and `[1.18.0]: …/compare/zt-zip-1.17...v1.18.0`.
- Re-running on the now-empty section → refuses with a non-zero exit.
- A simulated `1.19.0` release correctly links `[1.19.0]: …/compare/v1.18.0...v1.19.0`.

Historical `zt-zip-<version>` tags are left untouched.