### PR TITLE
Add comment regarding ".." check optimization

### DIFF
--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1139,6 +1139,11 @@ public final class ZipUtil {
     /* If we see the relative traversal string of ".." we need to make sure
      * that the outputdir + name doesn't leave the outputdir. See
      * DirectoryTraversalMaliciousTest for details.
+     *
+     * IMPORTANT: This optimization of checking for ".." before calling `getCanonicalFile()` seems to be safe only for
+     * the `java.io.File` API. If this is ever refactored to use `java.nio.file.Path#resolve(String)` this optimization
+     * must be omitted because `resolve` ignores the parent if the child is absolute (e.g. "/etc" or "C:/my-dir"),
+     * without it containing ".."
      */
     if (name.indexOf("..") != -1 && !destFile.getCanonicalFile().toPath().startsWith(outputDir.getCanonicalFile().toPath())) {
       throw new MaliciousZipException(outputDir, name);


### PR DESCRIPTION
This tries to avoid the case where the code is refactored to use `Path#resolve` but the `".."` check is erroneously kept, making it potentially possible to circumvent the Zip Slip mitigations.

This is based on my understanding of the behavior of the `java.io.File(File, String)` constructor; I might be wrong though.

However, it would be safer if the `name.indexOf("..") != -1` check did not exist here in the first place, and it always performed the Zip Slip check.