### PR TITLE
Apply directory-traversal guard in Zips fluent API unpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Hardened the relative path-traversal checks when unpacking, using `java.nio.file.Path` for consistent sub-directory containment checks.
+- The `Zips` fluent API unpack path (`Zips.get(...).unpack().destination(...).process()`) now applies the same path-traversal guard as `ZipUtil.unpack`, rejecting entries that resolve outside the destination directory; this covers both the plain and transformer branches ([#180](https://github.com/zeroturnaround/zt-zip/pull/180)).
 - In-place unpack now creates its temporary directory securely with `Files.createTempDirectory` (atomic, owner-only permissions) instead of a predictable, world-readable directory.
 
 ## [1.17] - 2024-01-28

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1135,7 +1135,7 @@ public final class ZipUtil {
     return checkDestinationFileForTraversal(outputDir, name, new File(outputDir, name));
   }
 
-  private static File checkDestinationFileForTraversal(File outputDir, String name, File destFile) throws IOException {
+  static File checkDestinationFileForTraversal(File outputDir, String name, File destFile) throws IOException {
     /* If we see the relative traversal string of ".." we need to make sure
      * that the outputdir + name doesn't leave the outputdir. See
      * DirectoryTraversalMaliciousTest for details.

--- a/src/main/java/org/zeroturnaround/zip/Zips.java
+++ b/src/main/java/org/zeroturnaround/zip/Zips.java
@@ -678,7 +678,7 @@ public class Zips {
       }
       visitedNames.add(entryName);
 
-      File file = new File(destination, entryName);
+      File file = ZipUtil.checkDestinationFileForTraversal(destination, entryName, new File(destination, entryName));
       if (zipEntry.isDirectory()) {
         FileUtils.forceMkdir(file);
         return;

--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -17,9 +17,13 @@ package org.zeroturnaround.zip;
  */
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import org.zeroturnaround.zip.transform.ZipEntryTransformer;
 
 import junit.framework.TestCase;
 
@@ -129,5 +133,64 @@ public class DirectoryTraversalMaliciousTest extends TestCase {
     catch (MaliciousZipException e) {
       assertFalse(new File(parent, "targetX/evil.txt").exists());
     }
+  }
+
+  /*
+   * The Zips fluent API has its own unpack implementation (Zips.UnpackingCallback)
+   * and must apply the same traversal guard as ZipUtil.unpack(...).
+   */
+  public void testZipsUnpackDoesntLeaveTarget() throws Exception {
+    File parent = Files.createTempDirectory("zt-zip-zips-traversal").toFile();
+    File target = new File(parent, "target");
+    target.mkdir();
+    File escaped = new File(parent, "escape/evil.txt");
+    File zip = createTraversalZip("../escape/evil.txt");
+
+    try {
+      Zips.get(zip).unpack().destination(target).process();
+      fail();
+    }
+    catch (MaliciousZipException e) {
+      assertFalse(escaped.exists());
+    }
+  }
+
+  public void testZipsUnpackWithTransformerDoesntLeaveTarget() throws Exception {
+    File parent = Files.createTempDirectory("zt-zip-zips-transform-traversal").toFile();
+    File target = new File(parent, "target");
+    target.mkdir();
+    File escaped = new File(parent, "escape/evil.txt");
+    final String entryName = "../escape/evil.txt";
+    File zip = createTraversalZip(entryName);
+
+    try {
+      Zips.get(zip)
+          .unpack()
+          .destination(target)
+          .addTransformer(entryName, new ZipEntryTransformer() {
+            public void transform(InputStream in, ZipEntry entry, ZipOutputStream out) throws IOException {
+              out.putNextEntry(new ZipEntry(entry.getName()));
+              out.closeEntry();
+            }
+          })
+          .process();
+      fail();
+    }
+    catch (MaliciousZipException e) {
+      assertFalse(escaped.exists());
+    }
+  }
+
+  private static File createTraversalZip(String entryName) throws IOException {
+    File zip = File.createTempFile("zips-traversal", ".zip");
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      out.putNextEntry(new ZipEntry(entryName));
+      out.closeEntry();
+    }
+    finally {
+      out.close();
+    }
+    return zip;
   }
 }

--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -181,6 +181,26 @@ public class DirectoryTraversalMaliciousTest extends TestCase {
     }
   }
 
+  /*
+   * A directory entry (trailing slash) escapes through forceMkdir rather than a
+   * file write, so the guard must run before the isDirectory() branch too.
+   */
+  public void testZipsUnpackDirectoryEntryDoesntLeaveTarget() throws Exception {
+    File parent = Files.createTempDirectory("zt-zip-zips-dir-traversal").toFile();
+    File target = new File(parent, "target");
+    target.mkdir();
+    File escaped = new File(parent, "escape");
+    File zip = createTraversalZip("../escape/");
+
+    try {
+      Zips.get(zip).unpack().destination(target).process();
+      fail();
+    }
+    catch (MaliciousZipException e) {
+      assertFalse(escaped.exists());
+    }
+  }
+
   private static File createTraversalZip(String entryName) throws IOException {
     File zip = File.createTempFile("zips-traversal", ".zip");
     ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));


### PR DESCRIPTION
## Problem

`ZipUtil.unpack(...)` rejects ZIP entries whose canonical path escapes the destination directory by throwing `MaliciousZipException` (the CVE-2018-1002201 guard, via `checkDestinationFileForTraversal`). The `Zips` fluent API, however, has a separate unpack path — `Zips.UnpackingCallback.process` — that built `new File(destination, entryName)` straight from the entry name and wrote it to disk with no boundary check.

As a result, a ZIP entry such as `../escape/poc.txt` extracted via

```java
Zips.get(zip).unpack().destination(outputDir).process();
```

is written **outside** `outputDir`. Both the plain-copy branch and the transformer branch (`addTransformer(...)`) are affected, since both write to the same `file`. `ZipUtil.unpack` of the same archive correctly throws `MaliciousZipException`.

## Fix

Route the resolved file through `ZipUtil.checkDestinationFileForTraversal` (changed from `private` to package-private) before any `mkdir` or write in `Zips.UnpackingCallback.process`, so both unpack implementations share a single traversal guard. The check runs before the directory branch as well, so a `../` directory entry cannot escape via `forceMkdir`.

## Tests

Added three regression tests to `DirectoryTraversalMaliciousTest`, covering the plain fluent unpack, the transformer branch, and a directory entry that would otherwise escape via `forceMkdir`. Each fails before the fix and passes after; the full suite is green. CHANGELOG updated under Security.
