### PR TITLE
Bound the ASI extra field symbolic-link length before allocating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the relative path-traversal checks when unpacking, using `java.nio.file.Path` for consistent sub-directory containment checks.
 - The `Zips` fluent API unpack path (`Zips.get(...).unpack().destination(...).process()`) now applies the same path-traversal guard as `ZipUtil.unpack`, rejecting entries that resolve outside the destination directory; this covers both the plain and transformer branches ([#180](https://github.com/zeroturnaround/zt-zip/pull/180)).
 - In-place unpack now creates its temporary directory securely with `Files.createTempDirectory` (atomic, owner-only permissions) instead of a predictable, world-readable directory.
+- `AsiExtraField` now validates the declared symbolic-link length against the bytes actually present before allocating, so a forged length in a crafted archive can no longer trigger a large (up to ~2 GB) memory allocation per entry while unpacking ([#181](https://github.com/zeroturnaround/zt-zip/pull/181)).
 
 ## [1.17] - 2024-01-28
 

--- a/src/main/java/org/zeroturnaround/zip/extra/AsiExtraField.java
+++ b/src/main/java/org/zeroturnaround/zip/extra/AsiExtraField.java
@@ -384,7 +384,13 @@ public class AsiExtraField implements ZipExtraField, Cloneable {
 
     int newMode = ZipShort.getValue(tmp, 0);
     // CheckStyle:MagicNumber OFF
-    byte[] linkArray = new byte[(int) ZipLong.getValue(tmp, 2)];
+    long linkLength = ZipLong.getValue(tmp, 2);
+    // The link length is read straight from the (attacker-controlled) extra field; bound it to the
+    // bytes actually present before allocating, so a forged length cannot trigger a huge allocation.
+    if (linkLength < 0 || linkLength > tmp.length - 10) {
+      throw new ZipException("Invalid symbolic link length " + linkLength + " in ASI extra field");
+    }
+    byte[] linkArray = new byte[(int) linkLength];
     uid = ZipShort.getValue(tmp, 6);
     gid = ZipShort.getValue(tmp, 8);
 

--- a/src/test/java/org/zeroturnaround/zip/extra/AsiExtraFieldTest.java
+++ b/src/test/java/org/zeroturnaround/zip/extra/AsiExtraFieldTest.java
@@ -1,0 +1,85 @@
+package org.zeroturnaround.zip.extra;
+
+/**
+ *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import java.util.zip.CRC32;
+import java.util.zip.ZipException;
+
+import junit.framework.TestCase;
+
+public class AsiExtraFieldTest extends TestCase {
+
+  /*
+   * Local file data layout consumed by parseFromLocalFileData(data, offset, length):
+   *   data[offset .. offset+3]   CRC32 of the remaining bytes (tmp)
+   *   tmp[0..1]                  mode (ZipShort)
+   *   tmp[2..5]                  symbolic-link length (ZipLong)
+   *   tmp[6..7]                  uid (ZipShort)
+   *   tmp[8..9]                  gid (ZipShort)
+   *   tmp[10..]                  link target bytes
+   */
+  private static byte[] localFileData(int mode, long declaredLinkLength, byte[] linkBytes) {
+    byte[] tmp = new byte[10 + linkBytes.length];
+    System.arraycopy(ZipShort.getBytes(mode), 0, tmp, 0, 2);
+    System.arraycopy(ZipLong.getBytes(declaredLinkLength), 0, tmp, 2, 4);
+    System.arraycopy(linkBytes, 0, tmp, 10, linkBytes.length);
+
+    CRC32 crc = new CRC32();
+    crc.update(tmp);
+
+    byte[] data = new byte[4 + tmp.length];
+    System.arraycopy(ZipLong.getBytes(crc.getValue()), 0, data, 0, 4);
+    System.arraycopy(tmp, 0, data, 4, tmp.length);
+    return data;
+  }
+
+  public void testParseRejectsOversizedLinkLengthWithoutAllocating() throws Exception {
+    // A forged link length far larger than the bytes actually present must be rejected before
+    // it is used to size an array, otherwise it triggers a ~2 GB allocation per parsed entry.
+    byte[] data = localFileData(0, Integer.MAX_VALUE, new byte[0]);
+
+    try {
+      new AsiExtraField().parseFromLocalFileData(data, 0, data.length);
+      fail();
+    }
+    catch (ZipException e) {
+      assertTrue(true);
+    }
+  }
+
+  public void testParseRejectsNegativeLinkLength() throws Exception {
+    byte[] data = localFileData(0, 0xFFFFFFFFL, new byte[0]); // reads as a negative int
+
+    try {
+      new AsiExtraField().parseFromLocalFileData(data, 0, data.length);
+      fail();
+    }
+    catch (ZipException e) {
+      assertTrue(true);
+    }
+  }
+
+  public void testParseAcceptsValidLink() throws Exception {
+    byte[] link = "x".getBytes("UTF-8");
+    byte[] data = localFileData(0120000 /* LINK_FLAG */, link.length, link);
+
+    AsiExtraField field = new AsiExtraField();
+    field.parseFromLocalFileData(data, 0, data.length);
+
+    assertTrue(field.isLink());
+    assertEquals("x", field.getLinkedFile());
+  }
+}


### PR DESCRIPTION
## Problem

`AsiExtraField.parseFromLocalFileData` (the ASI Unix-permissions extra field) reads the symbolic-link length straight from the extra-field bytes and uses it to size a `byte[]` **before** the bounding `System.arraycopy`:

```java
byte[] linkArray = new byte[(int) ZipLong.getValue(tmp, 2)];
...
System.arraycopy(tmp, 10, linkArray, 0, linkArray.length);
```

The length is attacker-controlled. The CRC check just before it is computed over the same attacker-supplied bytes, so it does not constrain the value. A crafted archive can declare a link length up to ~2 GB; since this field is parsed for **every** entry during `ZipUtil.unpack` (permission extraction), a multi-entry archive forces repeated large allocations and exhausts memory. A negative value (high bit set) yields `NegativeArraySizeException`.

## Fix

Validate the declared length against the bytes actually present before allocating, throwing `ZipException` for an out-of-range value:

```java
long linkLength = ZipLong.getValue(tmp, 2);
if (linkLength < 0 || linkLength > tmp.length - 10) {
  throw new ZipException("Invalid symbolic link length " + linkLength + " in ASI extra field");
}
byte[] linkArray = new byte[(int) linkLength];
```

## Tests

New `AsiExtraFieldTest` covers an oversized declared length (rejected before allocating — fails with `OutOfMemoryError` without the fix), a negative length, and a valid link that still parses. Full suite green.

Found during a follow-up audit after #180.
