### PR TITLE
Run the traversal guard before mkdir and create temp files atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Zips` fluent API unpack path (`Zips.get(...).unpack().destination(...).process()`) now applies the same path-traversal guard as `ZipUtil.unpack`, rejecting entries that resolve outside the destination directory; this covers both the plain and transformer branches ([#180](https://github.com/zeroturnaround/zt-zip/pull/180)).
 - In-place unpack now creates its temporary directory securely with `Files.createTempDirectory` (atomic, owner-only permissions) instead of a predictable, world-readable directory.
 - `AsiExtraField` now validates the declared symbolic-link length against the bytes actually present before allocating, so a forged length in a crafted archive can no longer trigger a large (up to ~2 GB) memory allocation per entry while unpacking ([#181](https://github.com/zeroturnaround/zt-zip/pull/181)).
+- `BackslashUnpacker` now validates the resolved path before creating any directories, so a backslash-separated `..\` entry can no longer create directories outside the output directory (the file write itself was already blocked).
+- `ZipUtil.explode`, `repack` and `unexplode` now create their working file or directory atomically (`File.createTempFile` / `Files.createTempDirectory`) instead of a predictable name next to the target, closing a symlink/TOCTOU race when the target sits in a shared directory; the predictable `FileUtils.getTempFileFor` helper is deprecated.
 
 ## [1.17] - 2024-01-28
 

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -1237,20 +1238,17 @@ public final class ZipUtil {
          * No errors detected in compressed data of backSlashTest.zip.
          */
         if (name.indexOf('\\') != -1) {
-          File parentDirectory = outputDir;
           String[] dirs = name.split("\\\\");
 
-          // lets create all the directories and the last entry is the file as EVERY entry is a file
-          for (int i = 0; i < dirs.length - 1; i++) {
-            File file = new File(parentDirectory, dirs[i]);
-            if (!file.exists()) {
-              FileUtils.forceMkdir(file);
-            }
-            parentDirectory = file;
+          // EVERY entry is a file; resolve the full path and validate it before creating any
+          // directories, so a "..\" entry cannot create directories outside the output directory.
+          File destFile = outputDir;
+          for (int i = 0; i < dirs.length; i++) {
+            destFile = new File(destFile, dirs[i]);
           }
-          File destFile = checkDestinationFileForTraversal(outputDir, name,
-            new File(parentDirectory, dirs[dirs.length - 1]));
+          checkDestinationFileForTraversal(outputDir, name, destFile);
 
+          FileUtils.forceMkdir(destFile.getParentFile());
           FileUtils.copy(in, destFile);
         }
         // it could be that there are just top level files that the unpacker is used for
@@ -1335,23 +1333,51 @@ public final class ZipUtil {
    */
   public static void explode(File zip) {
     try {
-      // Find a new unique name is the same directory
-      File tempFile = FileUtils.getTempFileFor(zip);
+      // Move the archive into a freshly created, owner-only temporary directory rather than a
+      // predictable name next to it, avoiding a symlink/TOCTOU race in a shared directory.
+      File tempDir = createTempDirFor(zip);
+      File tempFile = new File(tempDir, zip.getName());
 
-      // Rename the archive
+      // Move the archive into the temp directory
       FileUtils.moveFile(zip, tempFile);
 
-      // Unpack it
+      // Unpack it back to the original location
       unpack(tempFile, zip);
 
-      // Delete the archive
-      if (!tempFile.delete()) {
-        throw new IOException("Unable to delete file: " + tempFile);
-      }
+      // Delete the temporary directory and its contents
+      FileUtils.deleteDirectory(tempDir);
     }
     catch (IOException e) {
       throw ZipExceptionUtil.rethrow(e);
     }
+  }
+
+  /**
+   * Creates a fresh temporary directory for working on the given file, next to it when possible
+   * (so a later rename stays on the same filesystem). The directory is created atomically with
+   * owner-only permissions, so its name cannot be predicted or pre-created by another process.
+   */
+  private static File createTempDirFor(File file) throws IOException {
+    File parent = file.getParentFile();
+    String prefix = file.getName() + "_";
+    return (parent != null
+        ? Files.createTempDirectory(parent.toPath(), prefix)
+        : Files.createTempDirectory(prefix)).toFile();
+  }
+
+  /**
+   * Creates a fresh temporary file for working on the given file, next to it when possible (so a
+   * later rename stays on the same filesystem). The file is created atomically, so its name cannot
+   * be predicted or pre-created by another process.
+   */
+  private static File createTempFileFor(File file) throws IOException {
+    File parent = file.getParentFile();
+    // File.createTempFile requires a prefix of at least three characters.
+    String prefix = file.getName();
+    if (prefix.length() < 3) {
+      prefix = prefix + "tmp";
+    }
+    return File.createTempFile(prefix + "_", ".zip", parent);
   }
 
   /* Compressing single entries to ZIP files. */
@@ -1911,7 +1937,7 @@ public final class ZipUtil {
    */
   public static void repack(File zip, int compressionLevel) {
     try {
-      File tmpZip = FileUtils.getTempFileFor(zip);
+      File tmpZip = createTempFileFor(zip);
 
       repack(zip, tmpZip, compressionLevel);
 
@@ -2008,8 +2034,7 @@ public final class ZipUtil {
    */
   public static void unexplode(File dir, int compressionLevel) {
     try {
-      // Find a new unique name is the same directory
-      File zip = FileUtils.getTempFileFor(dir);
+      File zip = createTempFileFor(dir);
 
       // Pack it
       pack(dir, zip, compressionLevel);

--- a/src/main/java/org/zeroturnaround/zip/commons/FileUtils.java
+++ b/src/main/java/org/zeroturnaround/zip/commons/FileUtils.java
@@ -62,10 +62,14 @@ public class FileUtils extends FileUtilsV2_2 {
 
   /**
    * Find a non-existing file in the same directory using the same name as prefix.
-   * 
+   *
    * @param file file used for the name and location (it is not read or written).
    * @return a non-existing file in the same directory using the same name as prefix.
+   * @deprecated the returned name is predictable and the check-then-use gap allows a symlink/TOCTOU
+   *             race in a shared directory; create temporary files with {@link File#createTempFile}
+   *             or {@link java.nio.file.Files#createTempDirectory} instead.
    */
+  @Deprecated
   public static File getTempFileFor(File file) {
     File parent = file.getParentFile();
     String name = file.getName();

--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -104,6 +104,27 @@ public class DirectoryTraversalMaliciousTest extends TestCase {
   }
 
   /*
+   * The BackslashUnpacker splits an entry on "\" and walks the components. The traversal guard must
+   * run before any directory is created, otherwise a "..\" entry creates directories outside the
+   * target even though the file write is ultimately blocked.
+   */
+  public void testBackslashUnpackerDoesntCreateDirectoriesOutsideTarget() throws Exception {
+    File parent = Files.createTempDirectory("zt-zip-bs-traversal").toFile();
+    File target = new File(parent, "target");
+    target.mkdir();
+    File escaped = new File(parent, "escapedir");
+    File zip = createTraversalZip("..\\escapedir\\evil.txt");
+
+    try {
+      ZipUtil.iterate(zip, new ZipUtil.BackslashUnpacker(target));
+      fail();
+    }
+    catch (MaliciousZipException e) {
+      assertFalse(escaped.exists());
+    }
+  }
+
+  /*
    * An entry can leave the target without escaping its parent: a name like
    * "../targetX" resolves to a sibling directory whose path shares a prefix with
    * the target. A plain string prefix check treats that as inside the target; the


### PR DESCRIPTION
Two low-severity filesystem-safety hardenings found in a follow-up audit after #180.

## 1. `BackslashUnpacker` creates directories outside the target before the guard fires

`BackslashUnpacker.process` splits a `\`-separated entry name and creates each intermediate directory in a loop, then runs `checkDestinationFileForTraversal` only on the final file. So a `..\escapedir\evil.txt` entry creates `escapedir` outside the output directory before the guard throws — no file content escapes (the write is blocked), but empty directories are created outside the target.

Fix: resolve the full path first, validate it with the existing guard, and only then create the parent directories.

## 2. Predictable temp name + TOCTOU in `explode` / `repack` / `unexplode`

These used `FileUtils.getTempFileFor`, which picks a predictable `name_0`, `name_1`, … in the **same directory as the target** with a check-then-use loop. In a shared/world-writable directory an attacker can pre-create or symlink that name to influence or block the operation.

Fix: create the working file/directory atomically with `File.createTempFile` / `Files.createTempDirectory` (the same approach already used by the in-place unpack path), and deprecate the predictable `getTempFileFor` helper. `repack`/`unexplode` write (truncate) into the temp file, and `explode` moves the archive into a fresh owner-only temp directory; existing behavior is otherwise unchanged.

## Tests

Added `testBackslashUnpackerDoesntCreateDirectoriesOutsideTarget` (fails before the fix — the escaping directory is created; passes after). The existing `explode`/`repack`/`unexplode` tests cover the temp-file change; full suite green.
