### PR TITLE
Throw ZipException for an unwrap entry name with an out-of-range prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AsiExtraField` now validates the declared symbolic-link length against the bytes actually present before allocating, so a forged length in a crafted archive can no longer trigger a large (up to ~2 GB) memory allocation per entry while unpacking ([#181](https://github.com/zeroturnaround/zt-zip/pull/181)).
 - `BackslashUnpacker` now validates the resolved path before creating any directories, so a backslash-separated `..\` entry can no longer create directories outside the output directory (the file write itself was already blocked).
 - `ZipUtil.explode`, `repack` and `unexplode` now create their working file or directory atomically (`File.createTempFile` / `Files.createTempDirectory`) instead of a predictable name next to the target, closing a symlink/TOCTOU race when the target sits in a shared directory; the predictable `FileUtils.getTempFileFor` helper is deprecated.
+- `ZipUtil.unwrap` now throws a `ZipException` for an entry name whose path prefix resolves outside the name (such as a `~`- or `:`-prefixed name) instead of letting an unchecked `StringIndexOutOfBoundsException` abort the operation.
 
 ## [1.17] - 2024-01-28
 

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1311,7 +1311,14 @@ public final class ZipUtil {
     }
 
     private String getRootName(final String name) {
-      String newName = name.substring(FilenameUtils.getPrefixLength(name));
+      int prefixLength = FilenameUtils.getPrefixLength(name);
+      // getPrefixLength can return a value outside [0, name.length()] for names such as ":foo" (-1)
+      // or "~name" with no separator (length + 1); guard it so substring throws a ZipException rather
+      // than an unchecked StringIndexOutOfBoundsException out of unwrap.
+      if (prefixLength < 0 || prefixLength > name.length()) {
+        throw new ZipException("Entry " + name + " from the root of the zip is not supported");
+      }
+      String newName = name.substring(prefixLength);
       int idx = newName.indexOf(PATH_SEPARATOR);
       if (idx < 0) {
         throw new ZipException("Entry " + newName + " from the root of the zip is not supported");

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -749,6 +749,32 @@ public class ZipUtilTest extends TestCase {
     }
   }
 
+  public void testUnwrapEntryWithSpecialPrefixThrowsZipException() throws Exception {
+    // An entry name whose FilenameUtils prefix length falls outside the name (e.g. a "~"-prefixed
+    // name with no separator) must surface as a ZipException, not an unchecked StringIndexOutOfBounds.
+    File src = File.createTempFile("unwrap-prefix", ".zip");
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(src));
+    try {
+      out.putNextEntry(new ZipEntry("~evil"));
+      out.closeEntry();
+    }
+    finally {
+      out.close();
+    }
+
+    File destDir = Files.createTempDirectory("tempDir").toFile();
+    try {
+      ZipUtil.unwrap(src, destDir);
+      fail("expected a ZipException for an unsupported root entry name");
+    }
+    catch (ZipException e) {
+      assertEquals("Entry ~evil from the root of the zip is not supported", e.getMessage());
+    }
+    finally {
+      FileUtils.forceDelete(destDir);
+    }
+  }
+
   public void testUnwrapSingleRootWithStructure() throws Exception {
     File src = file("demo-single-root-dir.zip");
     File destDir = Files.createTempDirectory("tempDir").toFile();


### PR DESCRIPTION
## Problem

`Unwrapper.getRootName` does `name.substring(FilenameUtils.getPrefixLength(name))`. `getPrefixLength` can return a value outside `[0, name.length()]`:

- `-1` for a `:`-prefixed name
- `name.length() + 1` for a `~`-prefixed name with no separator (e.g. `~evil`, `~`)

`substring` then throws an unchecked `StringIndexOutOfBoundsException`, which `iterate` does not convert, so it escapes `unwrap` — defeating the graceful `ZipException` the method already raises for an entry that isn't under a single root. Affects `unwrap` only (no traversal, nothing written outside the target); the impact is an unexpected-exception DoS on a crafted archive.

## Fix

Validate the prefix length is within `[0, name.length()]` before calling `substring`, throwing the same "not supported" `ZipException` otherwise.

## Tests

`ZipUtilTest.testUnwrapEntryWithSpecialPrefixThrowsZipException` unwraps an archive with a `~evil` entry and expects a `ZipException`; it throws `StringIndexOutOfBoundsException` before the fix. Full suite green.

Found in a follow-up audit after #181/#182/#183.
