### PR TITLE
Close the transformer output stream and propagate its failure on unpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Zips` unpack with a transformer no longer hangs when the transformer produces no entry, and a transformer that throws now surfaces its real exception to the caller instead of a misleading "Write end dead" pipe error.
 - `Zips.addEntry`/`addEntries` no longer fail with "Stream closed" when adding a directory `FileSource`; a directory is now stored as a proper directory entry ([#138](https://github.com/zeroturnaround/zt-zip/issues/138)).
 - `ZipUtil.pack` no longer fails with `FileNotFoundException` when a directory contains a broken (dangling) symbolic link; such entries are skipped ([#122](https://github.com/zeroturnaround/zt-zip/issues/122)).
 

--- a/src/main/java/org/zeroturnaround/zip/Zips.java
+++ b/src/main/java/org/zeroturnaround/zip/Zips.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
@@ -705,6 +707,7 @@ public class Zips {
       final ZipInputStream zipIn = new ZipInputStream(pipedIn);
 
       ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(1);
+      final AtomicReference<Throwable> transformerError = new AtomicReference<Throwable>();
 
       try {
         newFixedThreadPool.execute(new Runnable() {
@@ -712,8 +715,13 @@ public class Zips {
             try {
               transformer.transform(entryIn, zipEntry, zipOut);
             }
-            catch (IOException e) {
-              ZipExceptionUtil.rethrow(e);
+            catch (Throwable e) {
+              transformerError.set(e);
+            }
+            finally {
+              // Always close the write end, so the reader sees a clean end of stream instead of
+              // blocking forever on getNextEntry() when the transformer produced no entry.
+              IOUtils.closeQuietly(zipOut);
             }
           }
         });
@@ -729,12 +737,33 @@ public class Zips {
         }
 
         newFixedThreadPool.shutdown();
+        try {
+          newFixedThreadPool.awaitTermination(1, TimeUnit.MINUTES);
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
         IOUtils.closeQuietly(pipedIn);
         IOUtils.closeQuietly(zipIn);
         IOUtils.closeQuietly(pipedOut);
         IOUtils.closeQuietly(zipOut);
       }
 
+      // Surface a failure from the transformer thread as the real cause, rather than the
+      // "Write end dead" pipe error the reader would otherwise see.
+      Throwable error = transformerError.get();
+      if (error != null) {
+        if (error instanceof IOException) {
+          throw (IOException) error;
+        }
+        if (error instanceof RuntimeException) {
+          throw (RuntimeException) error;
+        }
+        if (error instanceof Error) {
+          throw (Error) error;
+        }
+        throw new ZipException("Transforming entry '" + zipEntry.getName() + "' failed", error);
+      }
     }
   }
 }

--- a/src/test/java/org/zeroturnaround/zip/ZipsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipsTest.java
@@ -665,6 +665,77 @@ public class ZipsTest extends TestCase {
     }
   }
 
+  public void testUnpackTransformerWithoutOutputDoesNotHang() throws Exception {
+    final String fileName = "TestFile.txt";
+    final File newEntry = new File("src/test/resources/" + fileName);
+    final File src = new File("src/test/resources/demo-dirs.zip");
+    final File dest = File.createTempFile("temp", ".zip");
+
+    // A transformer that produces no entry must not leave the unpack blocked forever.
+    final ZipEntryTransformer dropping = new ZipEntryTransformer() {
+      public void transform(InputStream in, ZipEntry zipEntry, ZipOutputStream out) throws IOException {
+        // produce no entry
+      }
+    };
+
+    Thread worker = new Thread(new Runnable() {
+      public void run() {
+        Zips.get(src).unpack().addEntry(new FileSource(fileName, newEntry)).addTransformer(fileName, dropping).destination(dest).process();
+      }
+    });
+    worker.setDaemon(true);
+    worker.start();
+    worker.join(30000);
+    try {
+      assertFalse("Zips unpack with a transformer that writes no entry hung", worker.isAlive());
+    }
+    finally {
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
+  public void testUnpackTransformerIOExceptionSurfacesRealCause() throws Exception {
+    final String fileName = "TestFile.txt";
+    File newEntry = new File("src/test/resources/" + fileName);
+    File src = new File("src/test/resources/demo-dirs.zip");
+    File dest = File.createTempFile("temp", ".zip");
+
+    ZipEntryTransformer boom = new ZipEntryTransformer() {
+      public void transform(InputStream in, ZipEntry zipEntry, ZipOutputStream out) throws IOException {
+        throw new IOException("boom in transformer");
+      }
+    };
+
+    try {
+      Zips.get(src).unpack().addEntry(new FileSource(fileName, newEntry)).addTransformer(fileName, boom).destination(dest).process();
+      fail("expected the transformer IOException to surface");
+    }
+    catch (ZipException e) {
+      assertTrue("real transformer cause should be surfaced, was: " + messageChain(e), messageChainContains(e, "boom in transformer"));
+      assertFalse("should not surface the misleading pipe error, was: " + messageChain(e), messageChainContains(e, "Write end dead"));
+    }
+    finally {
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
+  private static boolean messageChainContains(Throwable t, String text) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c.getMessage() != null && c.getMessage().contains(text)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String messageChain(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      sb.append(c.getClass().getName()).append(": ").append(c.getMessage()).append(" | ");
+    }
+    return sb.toString();
+  }
+
   /**
    * The test will fail until https://github.com/zeroturnaround/zt-zip/issues/135
    * is fixed. I'm disabling this test to make a release though.


### PR DESCRIPTION
Two issues in `Zips.UnpackingCallback.transformIntoFile`, found in a follow-up audit. The transformer runs on a worker thread writing to a piped `ZipOutputStream`, while the main thread reads the result back via `zipIn.getNextEntry()`.

## 1. Hang when the transformer produces no entry (liveness / DoS)

The worker never closes `zipOut` — closing only happens in the main thread's `finally`, which is unreachable because the main thread is blocked at `zipIn.getNextEntry()` waiting for a local-file header that never arrives. A `ZipEntryTransformer` that legitimately writes no entry therefore blocks the unpack forever, on a **non-daemon** pool thread, so the JVM never exits either.

## 2. A transformer exception is lost behind "Write end dead"

When the transformer throws, the worker rethrew on its own thread, where the exception was lost (stderr only). The caller saw only a misleading `ZipException: ... Write end dead` from the broken pipe, never the real cause. (In practice the pool-thread "write end dead" detection is unreliable, so this path can hang too.)

## Fix

- Close the `ZipOutputStream` in the worker's `finally`, so the reader always sees a clean end of stream instead of blocking.
- Capture the transformer's throwable and, after the copy, rethrow it to the caller (preserving `IOException`/`RuntimeException`/`Error`; otherwise wrapped in `ZipException`) so the real cause surfaces.

## Tests

`ZipsTest` gains `testUnpackTransformerWithoutOutputDoesNotHang` (runs the unpack on a worker thread and asserts it completes — hangs without the fix) and `testUnpackTransformerIOExceptionSurfacesRealCause` (asserts the thrown exception chain contains the transformer's message, not "Write end dead"). The existing `testUnpackWithTransformer` happy path still passes; full suite green.
