### PR TITLE
Accept null bytes as a directory entry in ByteSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Zips` unpack with a transformer no longer hangs when the transformer produces no entry, and a transformer that throws now surfaces its real exception to the caller instead of a misleading "Write end dead" pipe error.
 - `Zips.addEntry`/`addEntries` no longer fail with "Stream closed" when adding a directory `FileSource`; a directory is now stored as a proper directory entry ([#138](https://github.com/zeroturnaround/zt-zip/issues/138)).
 - `ZipUtil.pack` no longer fails with `FileNotFoundException` when a directory contains a broken (dangling) symbolic link; such entries are skipped ([#122](https://github.com/zeroturnaround/zt-zip/issues/122)).
+- `ByteSource` (and the `byte[]` `ZipUtil.addEntry`/`replaceEntry` overloads) now accept `null` bytes as the documented directory entry instead of throwing `NullPointerException`.
 
 ### Security
 

--- a/src/main/java/org/zeroturnaround/zip/ByteSource.java
+++ b/src/main/java/org/zeroturnaround/zip/ByteSource.java
@@ -42,10 +42,11 @@ public class ByteSource implements ZipEntrySource {
 
   public ByteSource(String path, byte[] bytes, long time, int compressionMethod) {
     this.path = path;
-    this.bytes = (byte[])bytes.clone();
+    // A null byte array is allowed and denotes a directory entry (see getEntry/getInputStream).
+    this.bytes = bytes == null ? null : (byte[]) bytes.clone();
     this.time = time;
     this.compressionMethod = compressionMethod;
-    if(compressionMethod != -1) {
+    if(compressionMethod != -1 && bytes != null) {
       CRC32 crc32 = new CRC32();
       crc32.update(bytes);
       this.crc = crc32.getValue();

--- a/src/test/java/org/zeroturnaround/zip/ByteSourceTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ByteSourceTest.java
@@ -1,0 +1,31 @@
+package org.zeroturnaround.zip;
+
+/**
+ *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+import junit.framework.TestCase;
+
+public class ByteSourceTest extends TestCase {
+
+  public void testNullBytesDenotesDirectoryEntry() throws Exception {
+    // The byte[] addEntry/replaceEntry overloads document null bytes as "directory"; the
+    // constructor must accept that instead of throwing NullPointerException on bytes.clone().
+    ByteSource source = new ByteSource("dir/", null);
+
+    assertEquals("dir/", source.getPath());
+    assertNull(source.getInputStream());
+    assertEquals("dir/", source.getEntry().getName());
+  }
+}

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -231,6 +231,20 @@ public class ZipUtilTest extends TestCase {
     }
   }
 
+  public void testAddEntryWithNullBytesAddsDirectory() throws IOException {
+    // The byte[] addEntry overload documents null bytes as a directory entry.
+    File src = file("demo.zip");
+
+    File dest = File.createTempFile("temp", null);
+    try {
+      ZipUtil.addEntry(src, "newdir/", (byte[]) null, dest);
+      assertTrue("Result zip is missing directory entry 'newdir/'", ZipUtil.containsEntry(dest, "newdir/"));
+    }
+    finally {
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
   public void testUnexplode() throws IOException {
     File file = File.createTempFile("tempFile", null);
     File tmpDir = file.getParentFile();


### PR DESCRIPTION
## Problem

The `byte[]` `ZipUtil.addEntry`/`replaceEntry` overloads document their `bytes` parameter as *"new entry bytes (or null if directory)"*, and `ByteSource.getEntry()` / `getInputStream()` already handle a `null` array. But the `ByteSource` constructor calls `bytes.clone()` unconditionally, so a documented-valid call such as `ZipUtil.addEntry(zip, "dir/", (byte[]) null, dst)` throws `NullPointerException` before any archive work.

## Fix

Clone only when the array is non-null (and skip the CRC computation for a null array). One-line change to the constructor.

## Tests

`ByteSourceTest.testNullBytesDenotesDirectoryEntry` (constructor accepts null; `getInputStream()` is null; entry name preserved) and `ZipUtilTest.testAddEntryWithNullBytesAddsDirectory` (end-to-end `addEntry` with null bytes yields the `newdir/` directory entry). Both throw `NullPointerException` before the fix; full suite green.

Found in a follow-up audit after #181/#182/#183/#184/#185.
