### PR TITLE
Write a valid STORED entry for a null-bytes ByteSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Zips.addEntry`/`addEntries` no longer fail with "Stream closed" when adding a directory `FileSource`; a directory is now stored as a proper directory entry ([#138](https://github.com/zeroturnaround/zt-zip/issues/138)).
 - `ZipUtil.pack` no longer fails with `FileNotFoundException` when a directory contains a broken (dangling) symbolic link; such entries are skipped ([#122](https://github.com/zeroturnaround/zt-zip/issues/122)).
 - `ByteSource` (and the `byte[]` `ZipUtil.addEntry`/`replaceEntry` overloads) now accept `null` bytes as the documented directory entry instead of throwing `NullPointerException`.
+- `ByteSource` with `null` bytes and the `STORED` method now produces a valid empty entry (size 0, CRC 0) instead of failing with "STORED entry missing size, compressed size, or crc-32".
 
 ### Security
 

--- a/src/main/java/org/zeroturnaround/zip/ByteSource.java
+++ b/src/main/java/org/zeroturnaround/zip/ByteSource.java
@@ -46,9 +46,12 @@ public class ByteSource implements ZipEntrySource {
     this.bytes = bytes == null ? null : (byte[]) bytes.clone();
     this.time = time;
     this.compressionMethod = compressionMethod;
-    if(compressionMethod != -1 && bytes != null) {
+    if(compressionMethod != -1) {
+      // A STORED entry must declare its CRC; null bytes is an empty (directory) entry, whose CRC is 0.
       CRC32 crc32 = new CRC32();
-      crc32.update(bytes);
+      if (bytes != null) {
+        crc32.update(bytes);
+      }
       this.crc = crc32.getValue();
     } else {
       this.crc = -1;
@@ -63,6 +66,10 @@ public class ByteSource implements ZipEntrySource {
     ZipEntry entry = new ZipEntry(path);
     if (bytes != null) {
       entry.setSize(bytes.length);
+    }
+    else if (compressionMethod != -1) {
+      // A STORED entry must declare its size; null bytes is an empty (directory) entry.
+      entry.setSize(0);
     }
     if(compressionMethod != -1) {
       entry.setMethod(compressionMethod);

--- a/src/test/java/org/zeroturnaround/zip/ByteSourceTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ByteSourceTest.java
@@ -15,6 +15,8 @@ package org.zeroturnaround.zip;
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+import java.util.zip.ZipEntry;
+
 import junit.framework.TestCase;
 
 public class ByteSourceTest extends TestCase {
@@ -27,5 +29,18 @@ public class ByteSourceTest extends TestCase {
     assertEquals("dir/", source.getPath());
     assertNull(source.getInputStream());
     assertEquals("dir/", source.getEntry().getName());
+  }
+
+  public void testNullBytesWithStoredMethodIsAnEmptyEntry() throws Exception {
+    // A STORED entry must declare its size and CRC; with null bytes (a directory entry) those
+    // must be 0/0 so ZipOutputStream.putNextEntry accepts it instead of rejecting a STORED entry
+    // with a missing size/crc.
+    ByteSource source = new ByteSource("dir/", null, ZipEntry.STORED);
+    ZipEntry entry = source.getEntry();
+
+    assertEquals(ZipEntry.STORED, entry.getMethod());
+    assertEquals(0, entry.getSize());
+    assertEquals(0, entry.getCrc());
+    assertNull(source.getInputStream());
   }
 }

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -245,6 +245,20 @@ public class ZipUtilTest extends TestCase {
     }
   }
 
+  public void testAddEntryWithNullBytesAndStoredMethodAddsDirectory() throws IOException {
+    // A STORED directory entry (null bytes) must be written without "STORED entry missing size".
+    File src = file("demo.zip");
+
+    File dest = File.createTempFile("temp", null);
+    try {
+      ZipUtil.addEntry(src, "newdir/", (byte[]) null, dest, ZipEntry.STORED);
+      assertTrue("Result zip is missing directory entry 'newdir/'", ZipUtil.containsEntry(dest, "newdir/"));
+    }
+    finally {
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
   public void testUnexplode() throws IOException {
     File file = File.createTempFile("tempFile", null);
     File tmpDir = file.getParentFile();


### PR DESCRIPTION
Completes #187.

## Problem

#187 made a `ByteSource` with `null` bytes a directory entry, but only for the default/`DEFLATED` method. With the `STORED` method and `null` bytes, the constructor left `crc = -1` and `getEntry()` produced `method=STORED` with no size and no CRC, so `ZipOutputStream.putNextEntry` rejects it:

```
java.util.zip.ZipException: STORED entry missing size, compressed size, or crc-32
```

Reproduced via the public API: `ZipUtil.addEntry(zip, "dir/", (byte[]) null, dst, ZipEntry.STORED)`.

## Fix

A `null`-bytes entry is empty, so compute the CRC even for `null` bytes when a compression method is set (CRC of empty = 0) and set the entry size to 0. A `null`-bytes `STORED` entry is now a valid empty entry. The default (`-1`) and `DEFLATED` paths are unchanged.

## Tests

`ByteSourceTest.testNullBytesWithStoredMethodIsAnEmptyEntry` (entry is `STORED`, size 0, CRC 0) and `ZipUtilTest.testAddEntryWithNullBytesAndStoredMethodAddsDirectory` (end-to-end `addEntry(..., STORED)` writes the `newdir/` entry). Both fail before the fix; full suite green.

Found in a follow-up audit after #186/#187.
