### PR TITLE
Skip null-mapped entries in packEntries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Zips` unpack with a transformer no longer hangs when the transformer produces no entry, and a transformer that throws now surfaces its real exception to the caller instead of a misleading "Write end dead" pipe error.
 - `Zips.addEntry`/`addEntries` no longer fail with "Stream closed" when adding a directory `FileSource`; a directory is now stored as a proper directory entry ([#138](https://github.com/zeroturnaround/zt-zip/issues/138)).
 - `ZipUtil.pack` no longer fails with `FileNotFoundException` when a directory contains a broken (dangling) symbolic link; such entries are skipped ([#122](https://github.com/zeroturnaround/zt-zip/issues/122)).
+- `ZipUtil.packEntries`/`packEntry(File, File, NameMapper)` now skip an entry whose `NameMapper` returns `null` (the same convention as the directory `pack`) instead of throwing `NullPointerException` and leaving a partial zip.
 - `ByteSource` (and the `byte[]` `ZipUtil.addEntry`/`replaceEntry` overloads) now accept `null` bytes as the documented directory entry instead of throwing `NullPointerException`.
 - `ByteSource` with `null` bytes and the `STORED` method now produces a valid empty entry (size 0, CRC 0) instead of failing with "STORED entry missing size, compressed size, or crc-32".
 

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1603,10 +1603,14 @@ public final class ZipUtil {
       for (int i = 0; i < filesToPack.length; i++) {
         File fileToPack = filesToPack[i];
 
-        ZipEntry zipEntry = ZipEntryUtil.fromFile(mapper.map(fileToPack.getName()), fileToPack);
-        out.putNextEntry(zipEntry);
-        FileUtils.copy(fileToPack, out);
-        out.closeEntry();
+        // A NameMapper may return null to skip an entry, the same convention as the directory pack.
+        String name = mapper.map(fileToPack.getName());
+        if (name != null) {
+          ZipEntry zipEntry = ZipEntryUtil.fromFile(name, fileToPack);
+          out.putNextEntry(zipEntry);
+          FileUtils.copy(fileToPack, out);
+          out.closeEntry();
+        }
       }
     }
     catch (IOException e) {

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -103,6 +103,26 @@ public class ZipUtilTest extends TestCase {
     assertEquals(108, (new File(dest, "TestFile-II.txt")).length());
   }
 
+  public void testPackEntriesWithNullMappingSkipsEntry() throws IOException {
+    // A NameMapper returning null must skip the entry (as the directory pack does), not throw NPE.
+    File keep = file("TestFile.txt");
+    File skip = File.createTempFile("skipme", ".txt");
+    File dest = File.createTempFile("temp", ".zip");
+    try {
+      ZipUtil.packEntries(new File[] { keep, skip }, dest, new NameMapper() {
+        public String map(String name) {
+          return "TestFile.txt".equals(name) ? name : null;
+        }
+      });
+      assertTrue("kept entry should be present", ZipUtil.containsEntry(dest, "TestFile.txt"));
+      assertFalse("skipped entry should be absent", ZipUtil.containsEntry(dest, skip.getName()));
+    }
+    finally {
+      FileUtils.deleteQuietly(skip);
+      FileUtils.deleteQuietly(dest);
+    }
+  }
+
   public void testUnpackEntryFromFile() throws IOException {
     final String name = "foo";
     final byte[] contents = "bar".getBytes();


### PR DESCRIPTION
## Problem

`ZipUtil.packEntries` (and `packEntry(File, File, NameMapper)`, which delegates to it) passed the `NameMapper` result straight to `ZipEntryUtil.fromFile(name, file)`:

```java
ZipEntry zipEntry = ZipEntryUtil.fromFile(mapper.map(fileToPack.getName()), fileToPack);
```

A `NameMapper` returning `null` is the documented "skip this entry" convention, honored by the recursive directory `pack` (`if (name != null)`), `Zips`, `Unpacker`, and `Unwrapper`. `packEntries` instead produced `new ZipEntry(null)` → `NullPointerException`. Because the output stream is already open, the NPE also leaves a partial/corrupt zip at the destination.

## Fix

Skip the entry when the mapped name is `null`, mirroring the directory `pack`.

## Tests

`ZipUtilTest.testPackEntriesWithNullMappingSkipsEntry` packs two files with a mapper that returns `null` for one; the kept entry is present, the skipped one absent. It throws `NullPointerException` before the fix; full suite green.

Found in a follow-up audit after #186/#187/#188.
