### PR TITLE
Reject a destination equal to the source in the destructive ZipUtil methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Zips.addEntry`/`addEntries` no longer fail with "Stream closed" when adding a directory `FileSource`; a directory is now stored as a proper directory entry ([#138](https://github.com/zeroturnaround/zt-zip/issues/138)).
 - `ZipUtil.pack` no longer fails with `FileNotFoundException` when a directory contains a broken (dangling) symbolic link; such entries are skipped ([#122](https://github.com/zeroturnaround/zt-zip/issues/122)).
 - `ZipUtil.packEntries`/`packEntry(File, File, NameMapper)` now skip an entry whose `NameMapper` returns `null` (the same convention as the directory `pack`) instead of throwing `NullPointerException` and leaving a partial zip.
+- The `ZipUtil` methods that take a separate destination — `addEntry`/`addEntries`, `removeEntry`/`removeEntries`, `replaceEntry`/`replaceEntries`, `addOrReplaceEntries`, `transformEntry`/`transformEntries`, `repack` — now reject a destination equal to the source with an `IllegalArgumentException` instead of truncating and destroying the source before reading it; use the in-place variant (without a destination) instead.
 - `ByteSource` (and the `byte[]` `ZipUtil.addEntry`/`replaceEntry` overloads) now accept `null` bytes as the documented directory entry instead of throwing `NullPointerException`.
 - `ByteSource` with `null` bytes and the `STORED` method now produces a valid empty entry (size 0, CRC 0) instead of failing with "STORED entry missing size, compressed size, or crc-32".
 

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1136,6 +1136,20 @@ public final class ZipUtil {
     return checkDestinationFileForTraversal(outputDir, name, new File(outputDir, name));
   }
 
+  /**
+   * Guards the destructive "copy the source into destZip while changing it" methods against being
+   * pointed at their own source. These methods open (and thereby truncate) the destination before
+   * reading the source, so a {@code destZip} equal to the source would destroy it before a single
+   * byte is read. Callers that want to change a ZIP in place must use the variant without a
+   * destination.
+   */
+  private static void checkSourceAndDestinationAreNotTheSame(File sourceZip, File destZip) {
+    if (sourceZip.equals(destZip)) {
+      throw new IllegalArgumentException("Input (" + sourceZip.getAbsolutePath() + ") is the same as the destination! "
+          + "Please use the in-place method variant without a destination.");
+    }
+  }
+
   static File checkDestinationFileForTraversal(File outputDir, String name, File destFile) throws IOException {
     /* If we see the relative traversal string of ".." we need to make sure
      * that the outputdir + name doesn't leave the outputdir. See
@@ -1899,6 +1913,7 @@ public final class ZipUtil {
    *          compression level.
    */
   public static void repack(File srcZip, File dstZip, int compressionLevel) {
+    checkSourceAndDestinationAreNotTheSame(srcZip, dstZip);
 
     log.debug("Repacking '{}' into '{}'.", srcZip, dstZip);
 
@@ -2272,6 +2287,7 @@ public final class ZipUtil {
    *          new ZIP file created.
    */
   public static void addEntries(File zip, ZipEntrySource[] entries, File destZip) {
+    checkSourceAndDestinationAreNotTheSame(zip, destZip);
     if (log.isDebugEnabled()) {
       log.debug("Copying '" + zip + "' to '" + destZip + "' and adding " + Arrays.asList(entries) + ".");
     }
@@ -2411,6 +2427,7 @@ public final class ZipUtil {
    * @since 1.7
    */
   public static void removeEntries(File zip, String[] paths, File destZip) {
+    checkSourceAndDestinationAreNotTheSame(zip, destZip);
     if (log.isDebugEnabled()) {
       log.debug("Copying '" + zip + "' to '" + destZip + "' and removing paths " + Arrays.asList(paths) + ".");
     }
@@ -2734,6 +2751,7 @@ public final class ZipUtil {
    * @return <code>true</code> if at least one entry was replaced.
    */
   public static boolean replaceEntries(File zip, ZipEntrySource[] entries, File destZip) {
+    checkSourceAndDestinationAreNotTheSame(zip, destZip);
     if (log.isDebugEnabled()) {
       log.debug("Copying '" + zip + "' to '" + destZip + "' and replacing entries " + Arrays.asList(entries) + ".");
     }
@@ -2799,6 +2817,7 @@ public final class ZipUtil {
    *          new ZIP file created.
    */
   public static void addOrReplaceEntries(File zip, ZipEntrySource[] entries, File destZip) {
+    checkSourceAndDestinationAreNotTheSame(zip, destZip);
     if (log.isDebugEnabled()) {
       log.debug("Copying '" + zip + "' to '" + destZip + "' and adding/replacing entries " + Arrays.asList(entries)
           + ".");
@@ -2953,6 +2972,7 @@ public final class ZipUtil {
    * @return <code>true</code> if at least one entry was replaced.
    */
   public static boolean transformEntries(File zip, ZipEntryTransformerEntry[] entries, File destZip) {
+    checkSourceAndDestinationAreNotTheSame(zip, destZip);
     if (log.isDebugEnabled())
       log.debug("Copying '" + zip + "' to '" + destZip + "' and transforming entries " + Arrays.asList(entries) + ".");
 

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -37,6 +38,8 @@ import java.util.zip.ZipOutputStream;
 
 import org.zeroturnaround.zip.commons.FileUtils;
 import org.zeroturnaround.zip.commons.IOUtils;
+import org.zeroturnaround.zip.transform.StreamZipEntryTransformer;
+import org.zeroturnaround.zip.transform.ZipEntryTransformerEntry;
 
 import junit.framework.TestCase;
 
@@ -120,6 +123,85 @@ public class ZipUtilTest extends TestCase {
     finally {
       FileUtils.deleteQuietly(skip);
       FileUtils.deleteQuietly(dest);
+    }
+  }
+
+  public void testDestructiveOverloadsRejectSameSourceAndDestination() throws IOException {
+    // These methods open (truncate) the destination before reading the source, so passing the
+    // source as the destination would destroy it. They must reject it and leave the source intact.
+    final File zip = File.createTempFile("same-src-dest", ".zip");
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      zos.putNextEntry(new ZipEntry("a.txt"));
+      zos.write("aaa".getBytes());
+      zos.closeEntry();
+      zos.putNextEntry(new ZipEntry("b.txt"));
+      zos.write("bbb".getBytes());
+      zos.closeEntry();
+    }
+    finally {
+      zos.close();
+    }
+    long originalLength = zip.length();
+
+    final ZipEntrySource[] sources = new ZipEntrySource[] { new ByteSource("c.txt", "ccc".getBytes()) };
+    final ZipEntryTransformerEntry[] transforms = new ZipEntryTransformerEntry[] {
+        new ZipEntryTransformerEntry("a.txt", new StreamZipEntryTransformer() {
+          protected void transform(ZipEntry zipEntry, InputStream in, OutputStream out) throws IOException {
+            IOUtils.copy(in, out);
+          }
+        })
+    };
+
+    try {
+      assertRejectsSameFile("addEntry", new Runnable() {
+        public void run() { ZipUtil.addEntry(zip, "c.txt", "ccc".getBytes(), zip); }
+      });
+      assertRejectsSameFile("addEntries", new Runnable() {
+        public void run() { ZipUtil.addEntries(zip, sources, zip); }
+      });
+      assertRejectsSameFile("removeEntry", new Runnable() {
+        public void run() { ZipUtil.removeEntry(zip, "a.txt", zip); }
+      });
+      assertRejectsSameFile("removeEntries", new Runnable() {
+        public void run() { ZipUtil.removeEntries(zip, new String[] { "a.txt" }, zip); }
+      });
+      assertRejectsSameFile("replaceEntry", new Runnable() {
+        public void run() { ZipUtil.replaceEntry(zip, "a.txt", "zzz".getBytes(), zip); }
+      });
+      assertRejectsSameFile("replaceEntries", new Runnable() {
+        public void run() { ZipUtil.replaceEntries(zip, sources, zip); }
+      });
+      assertRejectsSameFile("addOrReplaceEntries", new Runnable() {
+        public void run() { ZipUtil.addOrReplaceEntries(zip, sources, zip); }
+      });
+      assertRejectsSameFile("transformEntry", new Runnable() {
+        public void run() { ZipUtil.transformEntry(zip, transforms[0], zip); }
+      });
+      assertRejectsSameFile("transformEntries", new Runnable() {
+        public void run() { ZipUtil.transformEntries(zip, transforms, zip); }
+      });
+      assertRejectsSameFile("repack", new Runnable() {
+        public void run() { ZipUtil.repack(zip, zip, 9); }
+      });
+
+      // The source must be untouched by all of the above.
+      assertEquals("source length changed", originalLength, zip.length());
+      assertTrue("source lost entry 'a.txt'", ZipUtil.containsEntry(zip, "a.txt"));
+      assertTrue("source lost entry 'b.txt'", ZipUtil.containsEntry(zip, "b.txt"));
+    }
+    finally {
+      FileUtils.deleteQuietly(zip);
+    }
+  }
+
+  private static void assertRejectsSameFile(String op, Runnable action) {
+    try {
+      action.run();
+      fail(op + " should reject the same file as source and destination");
+    }
+    catch (IllegalArgumentException e) {
+      // expected
     }
   }
 


### PR DESCRIPTION
## Problem

The `ZipUtil` methods that copy a ZIP into a separate destination while changing it — `addEntry`/`addEntries`, `removeEntry`/`removeEntries`, `replaceEntry`/`replaceEntries`, `addOrReplaceEntries`, `transformEntry(File,ZipEntryTransformerEntry,File)`/`transformEntries`, and `repack(File,File,int)` — open `new FileOutputStream(destZip)` **before** reading `zip`. When `destZip` equals `zip`, the source is truncated to zero before a byte is read, so its data is **irreversibly destroyed**; the call then fails with a misleading `ZipException: zip file is empty`. The javadoc states `zip` is "only read" and `destZip` is "created", so the contract is silently violated.

Only `transformEntry(File, String, ZipEntryTransformer, File)` guarded against this (and it even delegated to an unguarded sibling). This completes that guard — the earlier "Same-zip bug for the transformEntry method" fix — across all affected overloads.

## Fix

All the affected overloads funnel through six core methods that open the destination (`addEntries`, `removeEntries`, `replaceEntries`, `addOrReplaceEntries`, `transformEntries`, `repack`). Add a shared `checkSourceNotDestination` guard at the top of each, throwing `IllegalArgumentException` and pointing callers at the in-place variant (no destination), which already handles this correctly via a temp file.

## Tests

`ZipUtilTest.testDestructiveOverloadsRejectSameSourceAndDestination` calls all ten destructive overloads with `destZip == zip` and asserts each throws `IllegalArgumentException` and the source file is left intact (same length, both original entries still present). Fails before the fix (source destroyed); full suite green.

Found in a fifth follow-up audit; the rest of that pass converged clean.
