### PR TITLE
Skip applying a ZIP entry's permissions to the output directory itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ZipUtil.unpack` no longer applies a ZIP entry's stored file permissions to the output directory itself when an entry's name resolves to it (for example an entry named `/`), which could change the output directory's permissions ([GHSA-v2g6-7r9j-v6px](https://github.com/zeroturnaround/zt-zip/security/advisories/GHSA-v2g6-7r9j-v6px)).
+
 ## [1.18.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and these non-functional requirements:
 
 ## Security considerations
 
-When unpacking, zt-zip rejects entries whose path would resolve outside the target directory (the "Zip Slip" / directory-traversal class of attack), throwing `MaliciousZipException`.
+When unpacking, zt-zip rejects entries whose path would resolve outside the target directory (the "Zip Slip" / directory-traversal class of attack), throwing `MaliciousZipException`. An entry whose path resolves to the target directory itself (for example an entry named `/`) is a no-op: its stored file permissions are not applied to the target directory.
 
 zt-zip does **not** impose any limit on the decompressed size, compression ratio, or number of entries of an archive. Unpacking an untrusted archive can therefore exhaust memory or disk through a [zip bomb](https://en.wikipedia.org/wiki/Zip_bomb): `unpack` streams entries to disk but never caps the total bytes written or the entry count, and `unpackEntry` loads a whole entry into memory at once. If you extract archives from untrusted sources, validate the source and enforce your own limits — for example cap the number of entries, the size of each entry, and the total uncompressed size, and prefer streaming over `unpackEntry` for large or untrusted entries.
 

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -1151,19 +1152,78 @@ public final class ZipUtil {
   }
 
   static File checkDestinationFileForTraversal(File outputDir, String name, File destFile) throws IOException {
-    /* If we see the relative traversal string of ".." we need to make sure
-     * that the outputdir + name doesn't leave the outputdir. See
-     * DirectoryTraversalMaliciousTest for details.
+    /* If a ZIP entry name escapes the output directory (e.g. a ".." segment climbing above it) the
+     * destination must be rejected. See DirectoryTraversalMaliciousTest for details.
      *
-     * IMPORTANT: This optimization of checking for ".." before calling `getCanonicalFile()` seems to be safe only for
-     * the `java.io.File` API. If this is ever refactored to use `java.nio.file.Path#resolve(String)` this optimization
-     * must be omitted because `resolve` ignores the parent if the child is absolute (e.g. "/etc" or "C:/my-dir"),
-     * without it containing ".."
+     * isSafeDescendantEntryName recognises the common case of a genuine descendant with a cheap,
+     * allocation-free scan, so that only names it cannot clear fall through to getCanonicalFile().
+     * The filesystem access therefore stays off the hot path for every legitimate entry. It replaces
+     * the earlier `name.indexOf("..")` check, which also canonicalized names that merely contained
+     * ".." as a substring (e.g. "foo..bar").
+     *
+     * An entry that resolves to the output directory itself (e.g. "/") is intentionally allowed here:
+     * it is a harmless no-op for file/directory creation and is produced legitimately when unwrapping
+     * a single root directory. It is the Unpacker's permission handling that must not act on such an
+     * entry (see GHSA-v2g6-7r9j-v6px and {@link #destinationIsOutputDir}).
+     *
+     * IMPORTANT: the canonicalization below relies on the `java.io.File` API, where
+     * new File(outputDir, name) never treats an absolute-looking child (e.g. "/etc" or "C:/my-dir")
+     * as escaping the parent unless the name also contains "..". If this is ever refactored to use
+     * `java.nio.file.Path#resolve(String)` that no longer holds (resolve drops the parent for an
+     * absolute child), so isSafeDescendantEntryName's fast path must be revisited.
      */
-    if (name.indexOf("..") != -1 && !destFile.getCanonicalFile().toPath().startsWith(outputDir.getCanonicalFile().toPath())) {
+    if (isSafeDescendantEntryName(name)) {
+      return destFile;
+    }
+    Path canonicalDest = destFile.getCanonicalFile().toPath();
+    Path canonicalOutputDir = outputDir.getCanonicalFile().toPath();
+    if (!canonicalDest.startsWith(canonicalOutputDir)) {
       throw new MaliciousZipException(outputDir, name);
     }
     return destFile;
+  }
+
+  /**
+   * Tells whether a destination resolves to the output directory itself rather than to an entry
+   * inside it. Applying a ZIP entry's file permissions to such a destination would change the output
+   * directory's own permissions, which is the vulnerability described in GHSA-v2g6-7r9j-v6px; callers
+   * that apply permissions must skip the entry when this returns {@code true}.
+   *
+   * <p>The cheap {@link #isSafeDescendantEntryName} scan clears genuine descendants without touching
+   * the filesystem; only names that might resolve to the output directory are canonicalized.
+   */
+  static boolean destinationIsOutputDir(File outputDir, String name, File destFile) throws IOException {
+    if (isSafeDescendantEntryName(name)) {
+      return false;
+    }
+    return destFile.getCanonicalFile().equals(outputDir.getCanonicalFile());
+  }
+
+  /**
+   * Tells whether a ZIP entry name is guaranteed to resolve to a strict descendant of the output
+   * directory, i.e. it has at least one real path segment (neither empty nor ".") and no ".."
+   * segment. Such names can neither escape the output directory nor resolve to it, so they need no
+   * canonicalization and can skip the filesystem access in {@link #checkDestinationFileForTraversal}
+   * and {@link #destinationIsOutputDir}. Both '/' and '\' are treated as separators; a name that slips
+   * through to a canonical check because of an unusual separator is still handled correctly there.
+   */
+  private static boolean isSafeDescendantEntryName(String name) {
+    boolean hasRealSegment = false;
+    int segmentStart = 0;
+    int length = name.length();
+    for (int i = 0; i <= length; i++) {
+      if (i == length || name.charAt(i) == '/' || name.charAt(i) == '\\') {
+        int segmentLength = i - segmentStart;
+        if (segmentLength == 2 && name.charAt(segmentStart) == '.' && name.charAt(segmentStart + 1) == '.') {
+          return false; // a ".." segment: canonicalize to know where the name resolves
+        }
+        if (segmentLength > 0 && !(segmentLength == 1 && name.charAt(segmentStart) == '.')) {
+          hasRealSegment = true;
+        }
+        segmentStart = i + 1;
+      }
+    }
+    return hasRealSegment;
   }
 
   /**
@@ -1201,7 +1261,9 @@ public final class ZipUtil {
 
         try {
           ZTFilePermissions permissions = ZipEntryUtil.getZTFilePermissions(zipEntry);
-          if (permissions != null) {
+          // Skip entries that resolve to the output directory itself (e.g. "/"); applying their
+          // permissions would change the output directory's own permissions (GHSA-v2g6-7r9j-v6px).
+          if (permissions != null && !destinationIsOutputDir(outputDir, name, file)) {
             ZTFilePermissionsUtil.getDefaultStategy().setPermissions(file, permissions);
           }
         }

--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -19,7 +19,12 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -220,6 +225,129 @@ public class DirectoryTraversalMaliciousTest extends TestCase {
     catch (MaliciousZipException e) {
       assertFalse(escaped.exists());
     }
+  }
+
+  /*
+   * A ZIP entry whose name resolves to the output directory itself (e.g. "/") passes the traversal
+   * guard because it does not leave the target. Historically the Unpacker then applied the entry's
+   * file permissions to the output directory, which could widen them (e.g. make an owner-only
+   * directory world-accessible). See the advisory GHSA-v2g6-7r9j-v6px. Unpacking such an entry must
+   * complete without changing the output directory's permissions.
+   */
+  public void testUnpackDoesntChangeOutputDirPermissions() throws Exception {
+    assertUnpackDoesntChangeOutputDirPermissions("/");
+  }
+
+  /*
+   * "./" also resolves to the output directory itself, without containing "..", so it is not caught
+   * by looking for ".." alone.
+   */
+  public void testUnpackDoesntChangeOutputDirPermissionsForDotSlashEntry() throws Exception {
+    assertUnpackDoesntChangeOutputDirPermissions("./");
+  }
+
+  private void assertUnpackDoesntChangeOutputDirPermissions(String selfReferencingEntryName) throws Exception {
+    if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+      return; // POSIX permissions not supported on this platform; nothing to verify
+    }
+    File outputDir = Files.createTempDirectory("zt-zip-selfref-perms").toFile();
+    Path outputDirPath = outputDir.toPath();
+    Set<PosixFilePermission> ownerOnly = EnumSet.of(
+        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE);
+    Files.setPosixFilePermissions(outputDirPath, ownerOnly);
+    File zip = createZipWithPosixMode(selfReferencingEntryName, 0777);
+
+    ZipUtil.unpack(zip, outputDir);
+
+    assertEquals("Unpacking '" + selfReferencingEntryName + "' must not change the output directory permissions",
+        ownerOnly, Files.getPosixFilePermissions(outputDirPath));
+  }
+
+  /*
+   * Fixing the self-referencing case must not stop permissions from being applied to genuine entries
+   * inside the output directory.
+   */
+  public void testUnpackStillAppliesPermissionsToRegularEntry() throws Exception {
+    if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+      return; // POSIX permissions not supported on this platform; nothing to verify
+    }
+    File outputDir = Files.createTempDirectory("zt-zip-perms-applied").toFile();
+    File zip = createZipWithPosixMode("file.txt", 0750);
+
+    ZipUtil.unpack(zip, outputDir);
+
+    Set<PosixFilePermission> expected = EnumSet.of(
+        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
+        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE);
+    assertEquals(expected, Files.getPosixFilePermissions(new File(outputDir, "file.txt").toPath()));
+  }
+
+  /*
+   * Directly exercises the output-directory detection used to guard permission application: names
+   * that resolve to the output directory itself must be recognised (whether or not they contain
+   * ".."), while strict descendants must not.
+   */
+  public void testDestinationIsOutputDirDetection() throws Exception {
+    File outputDir = Files.createTempDirectory("zt-zip-isoutdir").toFile();
+    String[] selfReferencing = { "/", "//", "", ".", "./", "/.", "/./", "a/..", "a/../" };
+    for (String name : selfReferencing) {
+      assertTrue("'" + name + "' resolves to the output directory",
+          ZipUtil.destinationIsOutputDir(outputDir, name, new File(outputDir, name)));
+    }
+    String[] descendants = { "good.txt", "sub/file", "dir/file.txt", "a/b/c", "a/../b", "x/./y", "foo..bar" };
+    for (String name : descendants) {
+      assertFalse("'" + name + "' is a strict descendant",
+          ZipUtil.destinationIsOutputDir(outputDir, name, new File(outputDir, name)));
+    }
+  }
+
+  /*
+   * The guard rejects names that escape the output directory, whether via a leading ".." or a ".."
+   * that only escapes after a real segment (e.g. "sub/../../evil").
+   */
+  public void testGuardRejectsEscapingNames() throws Exception {
+    File outputDir = Files.createTempDirectory("zt-zip-guard-escape").toFile();
+    String[] escaping = { "..", "../evil", "../../evil", "a/../../evil", "sub/../../evil" };
+    for (String name : escaping) {
+      try {
+        ZipUtil.checkDestinationFileForTraversal(outputDir, name, new File(outputDir, name));
+        fail("Expected MaliciousZipException for entry name '" + name + "'");
+      }
+      catch (MaliciousZipException expected) {
+        // expected: the name escapes the output directory
+      }
+    }
+  }
+
+  /*
+   * The guard lets through names that resolve to a strict descendant of the output directory
+   * (including ones with "." or a cancelled ".." segment) as well as names that resolve to the
+   * output directory itself, which are harmless no-ops for extraction.
+   */
+  public void testGuardAllowsDescendantAndSelfReferenceNames() throws Exception {
+    File outputDir = Files.createTempDirectory("zt-zip-guard-good").toFile();
+    String[] allowedNames = { "good.txt", "sub/file", "dir/file.txt", "a/b/c", "a/../b", "x/./y", "foo..bar",
+        "/", "./", ".", "a/.." };
+    for (String name : allowedNames) {
+      File destFile = new File(outputDir, name);
+      assertSame("Entry name '" + name + "' should be allowed",
+          destFile, ZipUtil.checkDestinationFileForTraversal(outputDir, name, destFile));
+    }
+  }
+
+  private static File createZipWithPosixMode(String entryName, int posixMode) throws IOException {
+    File zip = File.createTempFile("zips-selfref", ".zip");
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));
+    try {
+      ZipEntry entry = new ZipEntry(entryName);
+      ZipEntryUtil.setZTFilePermissions(entry, ZTFilePermissionsUtil.fromPosixFileMode(posixMode));
+      out.putNextEntry(entry);
+      out.closeEntry();
+    }
+    finally {
+      out.close();
+    }
+    return zip;
   }
 
   private static File createTraversalZip(String entryName) throws IOException {


### PR DESCRIPTION
Fixes GHSA-v2g6-7r9j-v6px.

## Summary

When unpacking, a ZIP entry whose name resolves to the output directory itself (for example an entry named `/`) had its stored Unix file permissions applied to that directory, which could change the output directory's own permissions — for example widening an owner-only directory to world-accessible. The traversal guard permitted such entries because they do not leave the target directory.

The advisory lists `<= 1.17` as affected; the relevant code is unchanged in 1.18.0, so it is affected too.

## Change

- `ZipUtil.unpack` now skips the permission step when the destination resolves to the output directory (`destinationIsOutputDir`). Such self-referencing entries are still accepted by the traversal guard — they are harmless no-ops for file and directory creation and are produced legitimately when unwrapping a single root directory — so only the `Unpacker`'s permission handling changes. `BackslashUnpacker`, `Unwrapper` and the `Zips` fluent unpack never apply permissions, so `Unpacker` is the whole surface.
- The traversal guard's `name.indexOf("..")` check is replaced by an allocation-free segment scan (`isSafeDescendantEntryName`) that skips `getCanonicalFile()` for any name that is already a strict descendant. Canonicalization therefore stays off the hot path for legitimate entries and no longer runs for names that merely contain `..` as a substring (e.g. `foo..bar`).

## Tests

`DirectoryTraversalMaliciousTest`:

- POSIX-gated reproductions of the advisory for `/` and `./` asserting the output directory's permissions are unchanged after unpacking.
- A positive test that permissions are still applied to genuine entries inside the output directory.
- Unit coverage for `destinationIsOutputDir`, escape rejection, and descendant/self-reference acceptance.

All tests pass; the two integration tests fail if the permission guard is reverted.
