### PR TITLE
Make the unpack fast path aware of Windows path normalization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
@@ -23,13 +27,15 @@ jobs:
 
       # `build` runs `assemble` + `check` (which includes `test`). The Java 8
       # toolchain needed to compile is auto-provisioned by the foojay resolver.
+      # `shell: bash` makes ./gradlew work uniformly, including on the Windows runner.
       - name: Build and test
+        shell: bash
         run: ./gradlew build
 
       - name: Upload jar
         uses: actions/upload-artifact@v7
         with:
-          name: zt-zip
+          name: zt-zip-${{ matrix.os }}
           path: build/libs/*.jar
           retention-days: 7
 
@@ -37,6 +43,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.os }}
           path: build/reports/tests/
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Windows only** (no effect on other platforms): hardened the directory-traversal and output-directory checks used when unpacking against Windows path normalization. Windows strips a path component's trailing dots and spaces and treats `:` as a drive/stream separator, so an entry name like `" ."` could resolve to the output directory itself (re-applying the entry's permissions to it, [GHSA-v2g6-7r9j-v6px](https://github.com/zeroturnaround/zt-zip/security/advisories/GHSA-v2g6-7r9j-v6px)) and a name like `".. \evil.txt"` could escape the output directory. The allocation-free fast path that clears genuine descendant entry names (avoiding a `getCanonicalFile()` call) no longer clears such names; they are canonicalized and rejected as malicious when their canonical path cannot be resolved or does not stay inside the output directory. The output-directory check compares canonical `java.nio.file.Path`s so a self-referencing name is recognised even when `getCanonicalFile()` renders it with a trailing separator. Reported by [Marcono1234](https://github.com/Marcono1234).
+
 ## [1.18.1] - 2026-07-01
 
 ### Fixed

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,6 +65,17 @@ import org.zeroturnaround.zip.transform.ZipEntryTransformerEntry;
 public final class ZipUtil {
 
   private static final String PATH_SEPARATOR = "/";
+
+  /*
+   * Whether the JVM runs on a Windows filesystem, where a path component's trailing dots and spaces
+   * are stripped and ':' is treated as a drive/stream separator (see WinNTFileSystem.normalize and
+   * canonicalize). Those rewrites mean names like " ." can resolve to the output directory and names
+   * like ".. " can resolve to its parent, so the fast path in isSafeDescendantEntryName must fall
+   * back to canonicalization for such names on Windows. We key off File.separatorChar rather than
+   * os.name because it is set by the very same WinNTFileSystem that performs the normalization we are
+   * guarding against, so it is the correctly-coupled signal for whether that normalization applies.
+   */
+  private static final boolean WINDOWS_FILE_SYSTEM = File.separatorChar == '\\';
 
   /** Default compression level */
   public static final int DEFAULT_COMPRESSION_LEVEL = Deflater.DEFAULT_COMPRESSION;
@@ -1157,26 +1169,41 @@ public final class ZipUtil {
      *
      * isSafeDescendantEntryName recognises the common case of a genuine descendant with a cheap,
      * allocation-free scan, so that only names it cannot clear fall through to getCanonicalFile().
-     * The filesystem access therefore stays off the hot path for every legitimate entry. It replaces
-     * the earlier `name.indexOf("..")` check, which also canonicalized names that merely contained
-     * ".." as a substring (e.g. "foo..bar").
+     * The filesystem access therefore stays off the hot path for every legitimate entry. It clears
+     * more names than the earlier `name.indexOf("..")` check did (e.g. "foo..bar", which merely
+     * contained ".." as a substring), while on a Windows filesystem it also falls back to
+     * canonicalization for names whose components Windows would rewrite via trailing-dot/space
+     * stripping or a ':' drive/stream separator (e.g. "C:/evil" or a ".. " that normalizes to "..").
      *
      * An entry that resolves to the output directory itself (e.g. "/") is intentionally allowed here:
      * it is a harmless no-op for file/directory creation and is produced legitimately when unwrapping
      * a single root directory. It is the Unpacker's permission handling that must not act on such an
      * entry (see GHSA-v2g6-7r9j-v6px and {@link #destinationIsOutputDir}).
      *
-     * IMPORTANT: the canonicalization below relies on the `java.io.File` API, where
-     * new File(outputDir, name) never treats an absolute-looking child (e.g. "/etc" or "C:/my-dir")
-     * as escaping the parent unless the name also contains "..". If this is ever refactored to use
+     * IMPORTANT: the check below relies on the `java.io.File` API, where new File(outputDir, name)
+     * never treats an absolute-looking child (e.g. "/etc" or "C:/my-dir") as escaping the parent
+     * unless the name also contains "..". If this is ever refactored to use
      * `java.nio.file.Path#resolve(String)` that no longer holds (resolve drops the parent for an
      * absolute child), so isSafeDescendantEntryName's fast path must be revisited.
+     *
+     * A destination that cannot be resolved to a valid path is rejected: on a Windows filesystem a
+     * name with a component that ends with a space (e.g. ".. \evil.txt") or contains ':' makes
+     * getCanonicalFile()/toPath() throw, and such an entry cannot be safely written inside the output
+     * directory. The comparison uses Path so a trailing separator (e.g. a name resolving to the
+     * output directory itself, which getCanonicalFile() can render as "outputDir\") is normalized away
+     * rather than mistaken for an escape.
      */
     if (isSafeDescendantEntryName(name)) {
       return destFile;
     }
-    Path canonicalDest = destFile.getCanonicalFile().toPath();
     Path canonicalOutputDir = outputDir.getCanonicalFile().toPath();
+    Path canonicalDest;
+    try {
+      canonicalDest = destFile.getCanonicalFile().toPath();
+    }
+    catch (IOException | InvalidPathException e) {
+      throw new MaliciousZipException(outputDir, name);
+    }
     if (!canonicalDest.startsWith(canonicalOutputDir)) {
       throw new MaliciousZipException(outputDir, name);
     }
@@ -1190,22 +1217,48 @@ public final class ZipUtil {
    * that apply permissions must skip the entry when this returns {@code true}.
    *
    * <p>The cheap {@link #isSafeDescendantEntryName} scan clears genuine descendants without touching
-   * the filesystem; only names that might resolve to the output directory are canonicalized.
+   * the filesystem; only names that might resolve to the output directory are canonicalized. On a
+   * Windows filesystem this includes names whose components Windows rewrites by stripping trailing
+   * dots and spaces (e.g. {@code " ."}, which resolves to the output directory there). The comparison
+   * uses {@link Path}, not {@link File#equals}, because getCanonicalFile() can render such a
+   * self-reference with a trailing separator (e.g. {@code "outputDir\"}) that is not File-equal to
+   * the output directory but is the same path once normalized. If the destination cannot be resolved
+   * to a valid path (a Windows-illegal component), {@code true} is returned so an entry the traversal
+   * guard will reject anyway never has its permissions applied to the output directory.
    */
   static boolean destinationIsOutputDir(File outputDir, String name, File destFile) throws IOException {
     if (isSafeDescendantEntryName(name)) {
       return false;
     }
-    return destFile.getCanonicalFile().equals(outputDir.getCanonicalFile());
+    try {
+      return destFile.getCanonicalFile().toPath().equals(outputDir.getCanonicalFile().toPath());
+    }
+    catch (InvalidPathException e) {
+      return true;
+    }
   }
 
   /**
    * Tells whether a ZIP entry name is guaranteed to resolve to a strict descendant of the output
-   * directory, i.e. it has at least one real path segment (neither empty nor ".") and no ".."
-   * segment. Such names can neither escape the output directory nor resolve to it, so they need no
-   * canonicalization and can skip the filesystem access in {@link #checkDestinationFileForTraversal}
-   * and {@link #destinationIsOutputDir}. Both '/' and '\' are treated as separators; a name that slips
-   * through to a canonical check because of an unusual separator is still handled correctly there.
+   * directory, i.e. it has at least one real path segment (neither empty nor ".") and no segment that
+   * could escape the output directory or resolve to it. Such names can neither escape the output
+   * directory nor resolve to it, so they need no canonicalization and can skip the filesystem access
+   * in {@link #checkDestinationFileForTraversal} and {@link #destinationIsOutputDir}.
+   * <p>
+   * Both '/' and '\' are treated as separators on every platform. This is deliberate:
+   * {@link BackslashUnpacker} splits entry names on '\' on all platforms and builds its destination
+   * that way, then routes the raw name through this shared guard. If '\' were treated as a literal
+   * character on Unix, a name like {@code ..\escapedir\evil.txt} would be fast-allowed here while
+   * BackslashUnpacker escapes the output directory with it (guarded by
+   * {@code testBackslashUnpackerDoesntLeaveTarget}, which runs on Linux).
+   * <p>
+   * On a Windows filesystem a segment also forces canonicalization when it ends with '.' or ' ', or
+   * contains ':' — see {@link #isForbiddenFastPathSegment}. Windows strips trailing dots and spaces
+   * and treats ':' as a drive/stream separator, so such a segment can resolve to the output directory
+   * (e.g. {@code " ."}) or above it (e.g. a {@code ".. "} that normalizes to {@code ".."}). This
+   * makes the fast path a strict superset of the old protection: it keeps clearing normal names
+   * ({@code dir/sub/file.ext}) on every OS, and only Windows-special names fall back to a canonical
+   * check.
    */
   private static boolean isSafeDescendantEntryName(String name) {
     boolean hasRealSegment = false;
@@ -1213,17 +1266,60 @@ public final class ZipUtil {
     int length = name.length();
     for (int i = 0; i <= length; i++) {
       if (i == length || name.charAt(i) == '/' || name.charAt(i) == '\\') {
-        int segmentLength = i - segmentStart;
-        if (segmentLength == 2 && name.charAt(segmentStart) == '.' && name.charAt(segmentStart + 1) == '.') {
-          return false; // a ".." segment: canonicalize to know where the name resolves
+        if (isForbiddenFastPathSegment(name, segmentStart, i)) {
+          return false; // canonicalize to know where the name resolves
         }
-        if (segmentLength > 0 && !(segmentLength == 1 && name.charAt(segmentStart) == '.')) {
+        if (isRealSegment(name, segmentStart, i)) {
           hasRealSegment = true;
         }
         segmentStart = i + 1;
       }
     }
     return hasRealSegment;
+  }
+
+  /** Whether the segment name[start, end) is exactly ".". */
+  private static boolean isDot(String name, int start, int end) {
+    return end - start == 1 && name.charAt(start) == '.';
+  }
+
+  /** Whether the segment name[start, end) is exactly "..". */
+  private static boolean isDotDot(String name, int start, int end) {
+    return end - start == 2 && name.charAt(start) == '.' && name.charAt(start + 1) == '.';
+  }
+
+  /**
+   * Whether the segment name[start, end) contributes a real path component to the "has at least one
+   * real segment" tally, i.e. it is neither empty nor exactly ".". Skipping empty and "." segments
+   * means a name like {@code a/./b} still fast-allows.
+   */
+  private static boolean isRealSegment(String name, int start, int end) {
+    return end > start && !isDot(name, start, end);
+  }
+
+  /**
+   * Whether the segment name[start, end) disqualifies the whole name from the fast path, forcing a
+   * canonical check. That is the case when the segment is exactly ".." on any platform, or, on a
+   * Windows filesystem, when it is not exactly "." and either ends with '.' or ' ' (both stripped by
+   * Windows) or contains ':' (a drive/stream separator on Windows). See {@link #WINDOWS_FILE_SYSTEM}.
+   */
+  private static boolean isForbiddenFastPathSegment(String name, int start, int end) {
+    if (isDotDot(name, start, end)) {
+      return true;
+    }
+    if (!WINDOWS_FILE_SYSTEM || end == start || isDot(name, start, end)) {
+      return false;
+    }
+    char last = name.charAt(end - 1);
+    if (last == '.' || last == ' ') {
+      return true;
+    }
+    for (int i = start; i < end; i++) {
+      if (name.charAt(i) == ':') {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -335,6 +335,95 @@ public class DirectoryTraversalMaliciousTest extends TestCase {
     }
   }
 
+  /*
+   * These entry names only escape the output directory under Windows path normalization: Windows
+   * strips trailing spaces and dots from a path component, so ".. \evil.txt", ".. /evil.txt" (and the
+   * dotted variants) normalize to a "../" that climbs above the target. The pre-1.18.1 substring
+   * `indexOf("..")` check caught them; the allocation-free segment scan only flags a segment that is
+   * exactly "..", so the Windows-special forms must force a canonical check to stay protected.
+   *
+   * The assertion is the security invariant that holds on every OS: nothing is created outside the
+   * target. On Unix these are literal descendant filenames (containing a space) — no escape, no
+   * exception, the file lands inside the target. On Windows with the fix they are rejected with a
+   * MaliciousZipException; without the fix the escaped file would exist and the test fails.
+   */
+  public void testUnpackDoesntEscapeViaWindowsTrailingSpaceOrDot() throws Exception {
+    String[] maliciousNames = { ".. /evil.txt", ".. \\evil.txt", ".../evil.txt", ".. /.. /evil.txt" };
+    for (String name : maliciousNames) {
+      assertUnpackDoesntEscapeTarget(name, "evil.txt");
+    }
+  }
+
+  private void assertUnpackDoesntEscapeTarget(String entryName, String escapedLeafName) throws Exception {
+    File parent = Files.createTempDirectory("zt-zip-win-traversal").toFile();
+    File target = new File(parent, "target");
+    target.mkdir();
+    File escaped = new File(parent, escapedLeafName);
+    File zip = createTraversalZip(entryName);
+
+    try {
+      ZipUtil.unpack(zip, target);
+    }
+    catch (MaliciousZipException e) {
+      // acceptable: the name is rejected where Windows normalization would let it escape
+    }
+    assertFalse("Entry '" + entryName + "' must not create '" + escaped + "' outside the target",
+        escaped.exists());
+  }
+
+  /*
+   * Directly exercises the OS-aware fast-path classification behind the output-directory detection.
+   * A name like " ." (space + dot) resolves to the output directory itself on Windows because Windows
+   * strips the trailing dot and space, but is a literal descendant filename on Unix. The expectation
+   * therefore branches on the running filesystem.
+   */
+  public void testDestinationIsOutputDirDetectionForWindowsSpecialNames() throws Exception {
+    boolean windows = File.separatorChar == '\\';
+    File outputDir = Files.createTempDirectory("zt-zip-isoutdir-win").toFile();
+    // A single component that Windows normalizes away (trailing dot/space stripped) resolves to the
+    // output directory itself there; on Unix it is a literal descendant filename.
+    String[] windowsSelfReferencing = { " .", ". " };
+    for (String name : windowsSelfReferencing) {
+      assertEquals("'" + name + "' resolves to the output directory only on Windows",
+          windows, ZipUtil.destinationIsOutputDir(outputDir, name, new File(outputDir, name)));
+    }
+  }
+
+  /*
+   * Directly exercises the traversal guard for names that only escape under Windows normalization.
+   * On Windows the guard must reject them; on Unix they are literal descendants and pass through.
+   */
+  public void testGuardRejectsWindowsNormalizedEscapingNames() throws Exception {
+    boolean windows = File.separatorChar == '\\';
+    File outputDir = Files.createTempDirectory("zt-zip-guard-win").toFile();
+    // ".. " has its trailing space stripped by Windows to "..", which climbs above the output dir.
+    String[] windowsEscaping = { ".. /evil", ".. \\evil" };
+    for (String name : windowsEscaping) {
+      File destFile = new File(outputDir, name);
+      try {
+        ZipUtil.checkDestinationFileForTraversal(outputDir, name, destFile);
+        assertFalse("'" + name + "' must be rejected on Windows", windows);
+      }
+      catch (MaliciousZipException expected) {
+        assertTrue("'" + name + "' should only be rejected on Windows", windows);
+      }
+    }
+  }
+
+  /*
+   * Normal descendant names must keep taking the fast path (no exception) on every OS, including
+   * Windows, so the hardening does not needlessly canonicalize legitimate entries.
+   */
+  public void testGuardAllowsNormalNamesOnAllPlatforms() throws Exception {
+    File outputDir = Files.createTempDirectory("zt-zip-guard-normal").toFile();
+    String[] allowedNames = { "good.txt", "dir/file.txt", "a/b/c", "a/./b", "foo..bar", "foo.bar" };
+    for (String name : allowedNames) {
+      File destFile = new File(outputDir, name);
+      assertSame("Entry name '" + name + "' should be allowed on every OS",
+          destFile, ZipUtil.checkDestinationFileForTraversal(outputDir, name, destFile));
+    }
+  }
+
   private static File createZipWithPosixMode(String entryName, int posixMode) throws IOException {
     File zip = File.createTempFile("zips-selfref", ".zip");
     ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip));


### PR DESCRIPTION
Follow-up hardening to [GHSA-v2g6-7r9j-v6px](https://github.com/zeroturnaround/zt-zip/security/advisories/GHSA-v2g6-7r9j-v6px) (released in 1.18.1), from a review comment by [Marcono1234](https://github.com/Marcono1234) on #191.

### The problem

`isSafeDescendantEntryName` is an allocation-free fast path that clears genuine descendant ZIP-entry names during unpacking so they can skip the `getCanonicalFile()` traversal / output-directory checks. It only treated a path segment as unsafe when the segment was *exactly* `..`. That is unsound on a **Windows filesystem**, where `WinNTFileSystem` strips a component's trailing dots and spaces and treats `:` as a drive/stream separator:

- An entry named `" ."` (space + dot) has a "real" segment, so it was fast-allowed and `destinationIsOutputDir` returned `false` — but on Windows `new File(outputDir, " ").getCanonicalFile()` equals `outputDir`, so the entry's permissions get applied to the output directory. This re-opens the fixed advisory on Windows.
- An entry like `".. \evil.txt"` / `".. /evil.txt"` (a trailing space on a `..`) was fast-allowed because the segment is not exactly `..`, so the canonical check was skipped — but on Windows `.. ` normalizes to `..` and escapes the output directory. This is a traversal regression versus the pre-1.18.1 `indexOf("..")` substring check.

Both are Windows-only; Unix filesystems don't perform this normalization, which is why the existing tests pass on Linux/macOS.

### The fix

The fast path is now OS-aware. A segment forces canonicalization (disqualifies the fast path) when it is exactly `..` on any platform, or — **only on a Windows filesystem** — when it is not exactly `.` and either ends with `.` or ` `, or contains `:`. The OS predicate keys off `File.separatorChar` because that is set by the same `WinNTFileSystem` that performs the normalization being guarded against.

This is a strict superset of the previous protection: normal names (`dir/sub/file.ext`) still take the fast path on every OS including Windows, and behavior on non-Windows filesystems is unchanged. Both `/` and `\` remain separators on all platforms (`BackslashUnpacker` splits on `\` everywhere and routes names through this shared guard).

### Validation

The build workflow now runs on an `ubuntu-latest` / `macos-latest` / `windows-latest` matrix, so the Windows-specific behavior is actually exercised in CI. New tests in `DirectoryTraversalMaliciousTest` assert the cross-OS security invariant (nothing is created outside the target) where the mechanism diverges, and branch expectations on `File.separatorChar` for the classification unit tests. The existing POSIX-gated permission-integrity tests are unchanged.