### PR TITLE
Ignore the precomposed-Unicode charset fixture ghost on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ test.log
 release.sh
 rebel.xml
 src/main/resources/rebel.xml
+
+# macOS presents the committed NFD-encoded charset test fixture back in NFC form,
+# so its precomposed-Unicode name shows up as a phantom untracked file. The tracked
+# fixture is unaffected (Git never untracks a committed path via .gitignore).
+src/test/resources/umlauts-*.zip


### PR DESCRIPTION
The charset test fixture `src/test/resources/umlauts-*.zip` is committed with an **NFD**-encoded (decomposed) filename. On macOS (with `core.precomposeunicode=true`, the default), Git presents the checked-out file back in **NFC** (precomposed) form, so its precomposed name shows up as a phantom untracked file in every working tree on a Mac:

```
?? "src/test/resources/umlauts-\303\266\303\244\305\241.zip"
```

This adds `src/test/resources/umlauts-*.zip` to `.gitignore` to suppress that noise. It has no effect on Linux/Windows checkouts (no ghost there) and does not untrack the committed fixture — `.gitignore` never untracks an already-tracked path, so the NFD fixture stays in the repo and the charset tests keep passing.