### PR TITLE
Drop defunct ZeroTurnaround references from POM metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,10 +93,6 @@ mavenPublishing {
     name.set("ZT Zip")
     description.set(project.description)
     url.set("https://github.com/zeroturnaround/zt-zip")
-    organization {
-      name.set("ZeroTurnaround")
-      url.set("https://zeroturnaround.com/")
-    }
     licenses {
       license {
         name.set("The Apache Software License, Version 2.0")
@@ -114,16 +110,10 @@ mavenPublishing {
       developer {
         id.set("rein")
         name.set("Rein")
-        email.set("rein@zeroturnaround.com")
-        organization.set("ZeroTurnaround")
-        organizationUrl.set("https://zeroturnaround.com")
       }
       developer {
         id.set("toomasr")
         name.set("Toomas")
-        email.set("toomas@zeroturnaround.com")
-        organization.set("ZeroTurnaround")
-        organizationUrl.set("https://zeroturnaround.com")
       }
     }
     scm {


### PR DESCRIPTION
ZeroTurnaround no longer exists as a company and its website is dead, so the POM metadata pointing at it referenced nothing.

## Changes
- Remove the `organization` block (`ZeroTurnaround` / `https://zeroturnaround.com/`).
- Reduce the `rein` and `toomasr` developer entries to bare names, dropping their dead `@zeroturnaround.com` emails and `organization`/`organizationUrl`.

## Kept deliberately (backward compatibility / still valid)
- `group = "org.zeroturnaround"` — the Maven Central groupId; changing it would break consumers.
- The `github.com/zeroturnaround/zt-zip` project `url` and `scm` — the repo is still hosted there.
- The source-file copyright headers — Apache-2.0 attribution to the original author.
- The `nemecec` developer entry.

All POM fields required by Maven Central (name, description, url, license, developers, scm) remain present; publishing is unaffected.