### PR TITLE
Add maintainer copyright line to source headers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ByteSource.java
+++ b/src/main/java/org/zeroturnaround/zip/ByteSource.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/FileSource.java
+++ b/src/main/java/org/zeroturnaround/zip/FileSource.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/IdentityNameMapper.java
+++ b/src/main/java/org/zeroturnaround/zip/IdentityNameMapper.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/NameMapper.java
+++ b/src/main/java/org/zeroturnaround/zip/NameMapper.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ZTFileUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZTFileUtil.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ZipEntryCallback.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipEntryCallback.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ZipEntrySource.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipEntrySource.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ZipEntryUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipEntryUtil.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip;
 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ZipInfoCallback.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipInfoCallback.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/ZipUtil.java
+++ b/src/main/java/org/zeroturnaround/zip/ZipUtil.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/Zips.java
+++ b/src/main/java/org/zeroturnaround/zip/Zips.java
@@ -1,5 +1,6 @@
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/timestamps/Java8TimestampStrategy.java
+++ b/src/main/java/org/zeroturnaround/zip/timestamps/Java8TimestampStrategy.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip.timestamps;
 import java.nio.file.attribute.FileTime;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/timestamps/PreJava8TimestampStrategy.java
+++ b/src/main/java/org/zeroturnaround/zip/timestamps/PreJava8TimestampStrategy.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip.timestamps;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/timestamps/TimestampStrategy.java
+++ b/src/main/java/org/zeroturnaround/zip/timestamps/TimestampStrategy.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip.timestamps;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/zeroturnaround/zip/timestamps/TimestampStrategyFactory.java
+++ b/src/main/java/org/zeroturnaround/zip/timestamps/TimestampStrategyFactory.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip.timestamps;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/BrokenJarTest.java
+++ b/src/test/java/org/zeroturnaround/zip/BrokenJarTest.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip;
 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ByteSourceTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ByteSourceTest.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip;
 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/CharsetTest.java
+++ b/src/test/java/org/zeroturnaround/zip/CharsetTest.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip;
 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
+++ b/src/test/java/org/zeroturnaround/zip/DirectoryTraversalMaliciousTest.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip;
 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/FilePermissionsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/FilePermissionsTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/FileSourceTest.java
+++ b/src/test/java/org/zeroturnaround/zip/FileSourceTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/MainExamplesTest.java
+++ b/src/test/java/org/zeroturnaround/zip/MainExamplesTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZTFileUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZTFileUtilTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipEntryUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipEntryUtilTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipPreserveTimeStampJava8Test.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipPreserveTimeStampJava8Test.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipPreserveTimeStampTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipPreserveTimeStampTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipTransformTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipTransformTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilInPlaceTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilInPlaceTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip; 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipUtilTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/ZipsTest.java
+++ b/src/test/java/org/zeroturnaround/zip/ZipsTest.java
@@ -1,6 +1,7 @@
 package org.zeroturnaround.zip;
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/zeroturnaround/zip/extra/AsiExtraFieldTest.java
+++ b/src/test/java/org/zeroturnaround/zip/extra/AsiExtraFieldTest.java
@@ -2,6 +2,7 @@ package org.zeroturnaround.zip.extra;
 
 /**
  *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
+ *    Copyright (C) 2026 Neeme Praks
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Follow-up to #194. Adds a maintainer copyright line for the current sole maintainer to every source-file header, alongside the retained original ZeroTurnaround notice.

```
 *    Copyright (C) 2012 ZeroTurnaround LLC <support@zeroturnaround.com>
 *    Copyright (C) 2026 Neeme Praks
```

- The original ZeroTurnaround notice is kept unchanged — it is the required Apache-2.0 attribution for the original author.
- A single current year covers the independent-maintainer contributions without touching the work-for-hire status of the earlier ZeroTurnaround-era commits.
- 33 files, one line added each, no other changes. The seven CRLF-encoded files retain their line-ending convention.