### PR TITLE
Restrict the build workflow token to read access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
CodeQL flags the build workflow with `actions/missing-workflow-permissions` (medium), now that the workflow files are in scope:

> Workflow does not contain permissions

Without a `permissions:` block the job runs with the repository default `GITHUB_TOKEN` scope, which is wider than a build needs. The job checks out, builds and uploads artifacts — none of which writes back to the repository — so `contents: read` covers it.

Placed at the top level, the same way `dependency-submission.yml` declares its own (wider) scope.