### PR TITLE
Point the workflow triggers and README link at main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
   schedule:
     # Weekly scan to catch newly published queries against unchanged code.
     - cron: '23 4 * * 1'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,7 +4,7 @@ name: Dependency Submission
 # raise security alerts (and updates) for vulnerable transitive dependencies.
 on:
   push:
-    branches: [master, main]
+    branches: [main]
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ zt-zip does **not** impose any limit on the decompressed size, compression ratio
 
 ## Examples
 
-The examples don't include all the possible ways how to use the library but will give an overview. When you see a method that is useful but doesn't necessarily solve your use case then just head over to [ZipUtil.class](https://github.com/zeroturnaround/zt-zip/blob/master/src/main/java/org/zeroturnaround/zip/ZipUtil.java) file and see the sibling methods that are named the same but arguments might be different.
+The examples don't include all the possible ways how to use the library but will give an overview. When you see a method that is useful but doesn't necessarily solve your use case then just head over to [ZipUtil.class](https://github.com/zeroturnaround/zt-zip/blob/main/src/main/java/org/zeroturnaround/zip/ZipUtil.java) file and see the sibling methods that are named the same but arguments might be different.
 
 ### Unpacking
 


### PR DESCRIPTION
Follow-up to the default-branch rename (master → main).

- The `push` and `pull_request` triggers in `build.yml`, `codeql.yml` and `dependency-submission.yml` listed `[master, main]`. `master` no longer exists, so the entry is dead config — narrowed to `[main]`.
- The README linked `ZipUtil.java` on `/blob/master/`. GitHub's rename redirect still resolves it, but the link text shouldn't outlive the redirect.

No source or build changes. That this PR gets a Build and a CodeQL run is itself the check that the narrowed `pull_request` trigger still fires.